### PR TITLE
Adding Set-DesktopOptions for show/hide icons and titles

### DIFF
--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -1,4 +1,4 @@
 Resolve-Path $PSScriptRoot\*.ps1 | 
     % { . $_.ProviderPath }
 
-Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions
+Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions, Set-DesktopOptions

--- a/Boxstarter.WinConfig/Set-DesktopOptions.ps1
+++ b/Boxstarter.WinConfig/Set-DesktopOptions.ps1
@@ -1,7 +1,7 @@
 function Set-DesktopOptions {
 <#
 .SYNOPSIS
-Sets options for the Windows Task Bar
+Sets options for the Windows Desktop
 
 .PARAMETER Hide
 Hides Desktop Icons

--- a/Boxstarter.WinConfig/Set-DesktopOptions.ps1
+++ b/Boxstarter.WinConfig/Set-DesktopOptions.ps1
@@ -1,0 +1,46 @@
+function Set-DesktopOptions {
+<#
+.SYNOPSIS
+Sets options for the Windows Task Bar
+
+.PARAMETER Hide
+Hides Desktop Icons
+
+.PARAMETER Show
+Shows Desktop Icons
+
+.PARAMETER IconTitles
+Shows or Hides Icon Titles
+
+
+#>
+	[CmdletBinding(DefaultParameterSetName='hide')]
+	param(
+        [Parameter(ParameterSetName='show')]
+        [switch]$Show,
+        [Parameter(ParameterSetName='hide')]
+        [switch]$Hide,
+		[ValidateSet('On','Off')]
+		$IconTitles
+	)
+
+	$key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced'
+
+	if(Test-Path -Path $key) {
+		if($Show) 
+		{ 
+			Set-ItemProperty $key HideIcons 0
+        }
+        if($Hide){
+			Set-ItemProperty $key HideIcons 1 
+		} 
+
+		switch ($IconTitles) {
+			"Off" { Set-ItemProperty $key IconsOnly 1 }
+			"On" { Set-ItemProperty $key IconsOnly 0 }
+		}
+
+		Restart-Explorer
+	}	
+
+}


### PR DESCRIPTION
Offering the addition for setting desktop options for hiding/showing desktop icons and hiding/showing icon titles.
On new machines, in addition to showing hidden files and file extensions, I often hide desktop icons and turn on the Desktop toolbar on the taskbar.  I researched turning on the Desktop toolbar but didn't find an acceptable solution.
Thanks for consideration.

Ed