### PR TITLE
Telling chocolatey that it's ok to install files by passing -y.

### DIFF
--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -100,6 +100,7 @@ Intercepts Chocolatey call to check for reboots
     Write-BoxstarterMessage "Installing $($packageNames.Count) packages" -Verbose
     #backwards compatibility for Chocolatey versions prior to 0.9.8.21
     if(!$packageNames){$packageNames=$packageName}
+    $PSBoundParameters.yes = $true
     
     foreach($packageName in $packageNames){
         $PSBoundParameters.packageNames = $packageName


### PR DESCRIPTION
This will prevent chocolatey from writing an error to the console when installing something.