### PR TITLE
Windows 10 WindowsExplorerOptions  for Quick Access

### DIFF
--- a/Boxstarter.WinConfig/Set-WindowsExplorerOptions.ps1
+++ b/Boxstarter.WinConfig/Set-WindowsExplorerOptions.ps1
@@ -27,6 +27,24 @@ Setting this switch will cause Windows Explorer to show the full folder path in 
 .PARAMETER DisableShowFullPathInTitleBar
 Disables the showing of the full path in Windows Explorer Title Bar, see EnableShowFullPathInTitleBar
 
+.PARAMETER EnableOpenFileExplorerToQuickAccess
+Setting this switch will cause Windows Explorer to open itself to the Computer view, rather than the Quick Access view
+
+.PARAMETER DisableOpenFileExplorerToQuickAccess
+Disables the Quick Access location and shows Computer view when opening Windows Explorer, see EnableOpenFileExplorerToQuickAccess
+
+.PARAMETER EnableShowRecentFilesInQuickAccess
+Setting this switch will cause Windows Explorer to show recently used files in the Quick Access pane
+
+.PARAMETER DisableShowRecentFilesInQuickAccess
+Disables the showing of recently used files in the Quick Access pane, see EnableShowRecentFilesInQuickAccess
+
+.PARAMETER EnableShowFrequentFoldersInQuickAccess
+Setting this switch will cause Windows Explorer to show frequently used directories in the Quick Access pane
+
+.PARAMETER DisableShowFrequentFoldersInQuickAccess
+Disables the showing of frequently used directories in the Quick Access pane, see EnableShowFrequentFoldersInQuickAccess
+
 .LINK
 http://boxstarter.org
 
@@ -41,7 +59,13 @@ http://boxstarter.org
 		[switch]$EnableShowFileExtensions,
 		[switch]$DisableShowFileExtensions,
 		[switch]$EnableShowFullPathInTitleBar,
-		[switch]$DisableShowFullPathInTitleBar
+		[switch]$DisableShowFullPathInTitleBar,
+		[switch]$EnableOpenFileExplorerToQuickAccess,
+		[switch]$DisableOpenFileExplorerToQuickAccess,
+		[switch]$EnableShowRecentFilesInQuickAccess,
+		[switch]$DisableShowRecentFilesInQuickAccess,
+		[switch]$EnableShowFrequentFoldersInQuickAccess,
+		[switch]$DisableShowFrequentFoldersInQuickAccess
 	)
 
 	$PSBoundParameters.Keys | % {
@@ -52,11 +76,21 @@ http://boxstarter.org
         }
     }
 
-	$key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer'
+    $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer'
     $advancedKey = "$key\Advanced"
-	$cabinetStateKey = "$key\CabinetState"
+    $cabinetStateKey = "$key\CabinetState"
 
     Write-BoxstarterMessage "Setting Windows Explorer options..."
+
+    if(Test-Path -Path $key) {
+
+		if($EnableShowRecentFilesInQuickAccess) {Set-ItemProperty $key ShowRecent 1}
+		if($DisableShowRecentFilesInQuickAccess) {Set-ItemProperty $key ShowRecent 0}
+		if($EnableShowFrequentFoldersInQuickAccess) {Set-ItemProperty $key ShowFrequent 1}
+		if($DisableShowFrequentFoldersInQuickAccess) {Set-ItemProperty $key ShowFrequent 0}
+
+        Restart-Explorer
+    }
 
 	if(Test-Path -Path $advancedKey) {
 		if($EnableShowHiddenFilesFoldersDrives) {Set-ItemProperty $advancedKey Hidden 1}
@@ -68,6 +102,9 @@ http://boxstarter.org
 		if($EnableShowProtectedOSFiles) {Set-ItemProperty $advancedKey ShowSuperHidden 1}
 		if($DisableShowProtectedOSFiles) {Set-ItemProperty $advancedKey ShowSuperHidden 0}
 		
+        if($EnableOpenFileExplorerToQuickAccess) {Set-ItemProperty $advancedKey LaunchTo 2}
+		if($DisableOpenFileExplorerToQuickAccess) {Set-ItemProperty $advancedKey LaunchTo 1}
+
 		Restart-Explorer
 	}
 
@@ -78,3 +115,11 @@ http://boxstarter.org
 		Restart-Explorer		
 	}
 }
+
+Set-WindowsExplorerOptions -EnableOpenFileExplorerToQuickAccess
+Set-WindowsExplorerOptions -EnableShowRecentFilesInQuickAccess
+Set-WindowsExplorerOptions -EnableShowFrequentFoldersInQuickAccess
+
+Set-WindowsExplorerOptions -DisableOpenFileExplorerToQuickAccess
+Set-WindowsExplorerOptions -DisableShowRecentFilesInQuickAccess
+Set-WindowsExplorerOptions -DisableShowFrequentFoldersInQuickAccess

--- a/Boxstarter.WinConfig/Set-WindowsExplorerOptions.ps1
+++ b/Boxstarter.WinConfig/Set-WindowsExplorerOptions.ps1
@@ -50,25 +50,25 @@ http://boxstarter.org
 
 #>   
 
-	[CmdletBinding()]
-	param(
-		[switch]$EnableShowHiddenFilesFoldersDrives,
-		[switch]$DisableShowHiddenFilesFoldersDrives,
-		[switch]$EnableShowProtectedOSFiles,
-		[switch]$DisableShowProtectedOSFiles,
-		[switch]$EnableShowFileExtensions,
-		[switch]$DisableShowFileExtensions,
-		[switch]$EnableShowFullPathInTitleBar,
-		[switch]$DisableShowFullPathInTitleBar,
-		[switch]$EnableOpenFileExplorerToQuickAccess,
-		[switch]$DisableOpenFileExplorerToQuickAccess,
-		[switch]$EnableShowRecentFilesInQuickAccess,
-		[switch]$DisableShowRecentFilesInQuickAccess,
-		[switch]$EnableShowFrequentFoldersInQuickAccess,
-		[switch]$DisableShowFrequentFoldersInQuickAccess
-	)
+    [CmdletBinding()]
+    param(
+        [switch]$EnableShowHiddenFilesFoldersDrives,
+        [switch]$DisableShowHiddenFilesFoldersDrives,
+        [switch]$EnableShowProtectedOSFiles,
+        [switch]$DisableShowProtectedOSFiles,
+        [switch]$EnableShowFileExtensions,
+        [switch]$DisableShowFileExtensions,
+        [switch]$EnableShowFullPathInTitleBar,
+        [switch]$DisableShowFullPathInTitleBar,
+        [switch]$EnableOpenFileExplorerToQuickAccess,
+        [switch]$DisableOpenFileExplorerToQuickAccess,
+        [switch]$EnableShowRecentFilesInQuickAccess,
+        [switch]$DisableShowRecentFilesInQuickAccess,
+        [switch]$EnableShowFrequentFoldersInQuickAccess,
+        [switch]$DisableShowFrequentFoldersInQuickAccess
+    )
 
-	$PSBoundParameters.Keys | % {
+    $PSBoundParameters.Keys | % {
         if($_-like "En*"){ $other="Dis" + $_.Substring(2)}
         if($_-like "Dis*"){ $other="En" + $_.Substring(3)}
         if($PSBoundParameters[$_] -and $PSBoundParameters[$other]) {
@@ -83,43 +83,35 @@ http://boxstarter.org
     Write-BoxstarterMessage "Setting Windows Explorer options..."
 
     if(Test-Path -Path $key) {
+        if($EnableShowRecentFilesInQuickAccess) {Set-ItemProperty $key ShowRecent 1}
+        if($DisableShowRecentFilesInQuickAccess) {Set-ItemProperty $key ShowRecent 0}
 
-		if($EnableShowRecentFilesInQuickAccess) {Set-ItemProperty $key ShowRecent 1}
-		if($DisableShowRecentFilesInQuickAccess) {Set-ItemProperty $key ShowRecent 0}
-		if($EnableShowFrequentFoldersInQuickAccess) {Set-ItemProperty $key ShowFrequent 1}
-		if($DisableShowFrequentFoldersInQuickAccess) {Set-ItemProperty $key ShowFrequent 0}
+        if($EnableShowFrequentFoldersInQuickAccess) {Set-ItemProperty $key ShowFrequent 1}
+        if($DisableShowFrequentFoldersInQuickAccess) {Set-ItemProperty $key ShowFrequent 0}
 
         Restart-Explorer
     }
 
-	if(Test-Path -Path $advancedKey) {
-		if($EnableShowHiddenFilesFoldersDrives) {Set-ItemProperty $advancedKey Hidden 1}
-		if($DisableShowHiddenFilesFoldersDrives) {Set-ItemProperty $advancedKey Hidden 0}
-		
-		if($EnableShowFileExtensions) {Set-ItemProperty $advancedKey HideFileExt 0}
-		if($DisableShowFileExtensions) {Set-ItemProperty $advancedKey HideFileExt 1}
-		
-		if($EnableShowProtectedOSFiles) {Set-ItemProperty $advancedKey ShowSuperHidden 1}
-		if($DisableShowProtectedOSFiles) {Set-ItemProperty $advancedKey ShowSuperHidden 0}
-		
+    if(Test-Path -Path $advancedKey) {
+        if($EnableShowHiddenFilesFoldersDrives) {Set-ItemProperty $advancedKey Hidden 1}
+        if($DisableShowHiddenFilesFoldersDrives) {Set-ItemProperty $advancedKey Hidden 0}
+
+        if($EnableShowFileExtensions) {Set-ItemProperty $advancedKey HideFileExt 0}
+        if($DisableShowFileExtensions) {Set-ItemProperty $advancedKey HideFileExt 1}
+
+        if($EnableShowProtectedOSFiles) {Set-ItemProperty $advancedKey ShowSuperHidden 1}
+        if($DisableShowProtectedOSFiles) {Set-ItemProperty $advancedKey ShowSuperHidden 0}
+
         if($EnableOpenFileExplorerToQuickAccess) {Set-ItemProperty $advancedKey LaunchTo 2}
-		if($DisableOpenFileExplorerToQuickAccess) {Set-ItemProperty $advancedKey LaunchTo 1}
+        if($DisableOpenFileExplorerToQuickAccess) {Set-ItemProperty $advancedKey LaunchTo 1}
 
-		Restart-Explorer
-	}
+        Restart-Explorer
+    }
 
-	if(Test-Path -Path $cabinetStateKey) {
-		if($EnableShowFullPathInTitleBar) {Set-ItemProperty $cabinetStateKey FullPath  1}
-		if($DisableShowFullPathInTitleBar) {Set-ItemProperty $cabinetStateKey FullPath  0}
-		
-		Restart-Explorer		
-	}
+    if(Test-Path -Path $cabinetStateKey) {
+        if($EnableShowFullPathInTitleBar) {Set-ItemProperty $cabinetStateKey FullPath  1}
+        if($DisableShowFullPathInTitleBar) {Set-ItemProperty $cabinetStateKey FullPath  0}
+
+        Restart-Explorer		
+    }
 }
-
-Set-WindowsExplorerOptions -EnableOpenFileExplorerToQuickAccess
-Set-WindowsExplorerOptions -EnableShowRecentFilesInQuickAccess
-Set-WindowsExplorerOptions -EnableShowFrequentFoldersInQuickAccess
-
-Set-WindowsExplorerOptions -DisableOpenFileExplorerToQuickAccess
-Set-WindowsExplorerOptions -DisableShowRecentFilesInQuickAccess
-Set-WindowsExplorerOptions -DisableShowFrequentFoldersInQuickAccess

--- a/Web/WinConfig.cshtml
+++ b/Web/WinConfig.cshtml
@@ -61,11 +61,11 @@ Set-CornerNavigationOptions -DisableUpperRightCornerShowCharms -DisableUpperLeft
 <h3>Set-WindowsExplorerOptions</h3>
 <p>Sets options on the Windows Explorer shell</p>
 <pre>
-Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowProtectedOSFiles -EnableShowFileExtensions -EnableShowFullPathInTitleBar
+Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowProtectedOSFiles -EnableShowFileExtensions -EnableShowFullPathInTitleBar -EnableOpenFileExplorerToQuickAccess -EnableShowRecentFilesInQuickAccess -EnableShowFrequentFoldersInQuickAccess
 </pre>
 <p>It is also possible to do the converse actions, if required.</p>
 <pre>
-Set-WindowsExplorerOptions -DisableShowHiddenFilesFoldersDrives -DisableShowProtectedOSFiles -DisableShowFileExtensions -DisableShowFullPathInTitleBar
+Set-WindowsExplorerOptions -DisableShowHiddenFilesFoldersDrives -DisableShowProtectedOSFiles -DisableShowFileExtensions -DisableShowFullPathInTitleBar -DisableOpenFileExplorerToQuickAccess -DisableShowRecentFilesInQuickAccess -DisableShowFrequentFoldersInQuickAccess
 </pre>
 
 <h3>Set-TaskbarOptions</h3>


### PR DESCRIPTION
This change adds 3 Windows 10 specific options. You can now tweak settings for:

- Open File Explorer To Quick Access or Computer
- Show recently used files
- Show frequently used folders/directories

![](https://cloud.githubusercontent.com/assets/930731/8630305/c97147b6-2718-11e5-8c6f-0c6b8bcd67a1.png)

All this taken from [Issue 99](https://github.com/mwrock/boxstarter/issues/99)

Tabs converted to spaces simply for consistency, not religiosity. Sorry that it looks to be such a large set of changes to almost all lines. It's only a whitespace change, and I sure didn't mean to step into tabs/spaces. I used PowerShell ISE to dev this change, and it uses spaces by default and this is the result...
 
I followed existing naming conventions, and simply created lines of code where they belonged alongside similar reg key modifiers.
 
The naming convention was like `Enable\Disable<something>QuickAccess` as Quick Access is the feature being tweaked in Win 10.

Note the `if` block at line 85 whose concern was the reg path simply at `$key`. I placed this block before the `advanced` and `cabinetState` because it theoretically/logically comes before.

**Usage**

```
Set-WindowsExplorerOptions -EnableOpenFileExplorerToQuickAccess
Set-WindowsExplorerOptions -EnableShowRecentFilesInQuickAccess
Set-WindowsExplorerOptions -EnableShowFrequentFoldersInQuickAccess

Set-WindowsExplorerOptions -DisableOpenFileExplorerToQuickAccess
Set-WindowsExplorerOptions -DisableShowRecentFilesInQuickAccess
Set-WindowsExplorerOptions -DisableShowFrequentFoldersInQuickAccess
```
