### PR TITLE
Add Disable-GameBarTips

### DIFF
--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -1,4 +1,4 @@
 Resolve-Path $PSScriptRoot\*.ps1 | 
     % { . $_.ProviderPath }
 
-Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions
+Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Disable-GameBarTips, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions

--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.pssproj
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.pssproj
@@ -30,6 +30,7 @@
     <Compile Include="boxstarter.WinConfig.psd1" />
     <Compile Include="Boxstarter.WinConfig.psm1" />
     <Compile Include="Disable-InternetExplorerESC.ps1" />
+    <Compile Include="Disable-GameBarTips.ps1" />
     <Compile Include="Disable-UAC.ps1" />
     <Compile Include="Enable-RemoteDesktop.ps1" />
     <Compile Include="Enable-UAC.ps1" />

--- a/Boxstarter.WinConfig/Disable-GameBarTips.ps1
+++ b/Boxstarter.WinConfig/Disable-GameBarTips.ps1
@@ -1,0 +1,19 @@
+function Disable-GameBarTips {
+<#
+.SYNOPSIS
+Turns off the tips displayed by the XBox GameBar
+
+.LINK
+http://boxstarter.org
+
+#>
+    $path = "HKCU:\SOFTWARE\Microsoft\GameBar"
+    if(!(Test-Path $path)) {
+        md $path
+    }
+
+    New-ItemProperty -LiteralPath $path -Name "ShowStartupPanel" -Value 0 -PropertyType "DWord" -ErrorAction SilentlyContinue
+    Set-ItemProperty -LiteralPath $path -Name "ShowStartupPanel" -Value 0
+
+    Write-Output "GameBar Tips have been disabled."
+}

--- a/Boxstarter.WinConfig/Disable-GameBarTips.ps1
+++ b/Boxstarter.WinConfig/Disable-GameBarTips.ps1
@@ -9,7 +9,7 @@ http://boxstarter.org
 #>
     $path = "HKCU:\SOFTWARE\Microsoft\GameBar"
     if(!(Test-Path $path)) {
-        md $path
+        New-Item $path
     }
 
     New-ItemProperty -LiteralPath $path -Name "ShowStartupPanel" -Value 0 -PropertyType "DWord" -ErrorAction SilentlyContinue

--- a/Web/WinConfig.cshtml
+++ b/Web/WinConfig.cshtml
@@ -10,6 +10,9 @@
 <h3>Disable-InternetExplorerESC</h3>
 <p>Turns off Internet Explorer Enhanced Security Configuration that is on by default on Server OS versions.</p>
 
+<h3>Disable-GameBarTips</h3>
+<p>Turns off the GameBar Tips of Windows 10 that are shown when a game - or what Windows 10 thinks is a game - is launched.</p>
+
 <h3>Disable-MicrosoftUpdate</h3>
 <p>Turns off the Windows Update option to include updates for other Microsoft products installed on the system.</p>
 


### PR DESCRIPTION
This function allows to disable the annoying tips from the XBox GameBar
in Windows 10 that are shown when a game starts up. There are two
problems with this:
1. Apparently, it breaks some games
2. Windows 10 also shows it for some applications like the x64 version
of Total Commander