### PR TITLE
Add Set-UpdatesDeliveryMode

### DIFF
--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -1,4 +1,22 @@
 Resolve-Path $PSScriptRoot\*.ps1 | 
     % { . $_.ProviderPath }
 
-Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions
+Export-ModuleMember `
+    Disable-UAC, `
+    Enable-UAC, `
+    Get-UAC, `
+    Disable-InternetExplorerESC, `
+    Get-ExplorerOptions, `
+    Set-TaskbarSmall, `
+    Install-WindowsUpdate, `
+    Move-LibraryDirectory, `
+    Enable-RemoteDesktop, `
+    Set-ExplorerOptions, `
+    Get-LibraryNames, `
+    Update-ExecutionPolicy, `
+    Enable-MicrosoftUpdate, `
+    Disable-MicrosoftUpdate, `
+    Set-StartScreenOptions, `
+    Set-CornerNavigationOptions, `
+    Set-WindowsExplorerOptions, `
+    Set-TaskbarOptions

--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -6,6 +6,7 @@ Export-ModuleMember `
     Enable-UAC, `
     Get-UAC, `
     Disable-InternetExplorerESC, `
+    Set-UpdatesDeliveryMode, `
     Get-ExplorerOptions, `
     Set-TaskbarSmall, `
     Install-WindowsUpdate, `

--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.pssproj
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.pssproj
@@ -30,6 +30,7 @@
     <Compile Include="boxstarter.WinConfig.psd1" />
     <Compile Include="Boxstarter.WinConfig.psm1" />
     <Compile Include="Disable-InternetExplorerESC.ps1" />
+    <Compile Include="Set-UpdatesDeliveryMode.ps1" />
     <Compile Include="Disable-UAC.ps1" />
     <Compile Include="Enable-RemoteDesktop.ps1" />
     <Compile Include="Enable-UAC.ps1" />

--- a/Boxstarter.WinConfig/Set-UpdatesDeliveryMode.ps1
+++ b/Boxstarter.WinConfig/Set-UpdatesDeliveryMode.ps1
@@ -1,0 +1,38 @@
+function Set-UpdatesDeliveryMode {
+<#
+.SYNOPSIS
+Sets the mode in which Updates are delivered. Allows to set the Update Bandwith Sharing option.
+
+.PARAMETER DeliveryMode
+Specifies whether updates are coming from additional sources in addition to Microsoft.
+Valid inputs are:
+    * Off: Updates are only coming from Microsofts servers.
+    * LocalNetwork: Updates are coming from Microsoft and additionally, updates are received and also delivered to other PCs in the local network.
+    * Internet: Updates are coming from Microsoft and additionally, updates are received and also delivered to other PCs in the local network or on the internet.
+
+#>
+    param(
+        [ValidateSet('Off','LocalNetwork','Internet')]
+		$DeliveryMode
+    )
+    $path1 = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config"
+    $path2 = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization"
+    if(!(Test-Path $path1)) {
+        New-Item $path1
+    }
+    if(!(Test-Path $path2)) {
+        New-Item $path2
+    }
+
+    switch($DeliveryMode) {
+        "Off" { $value = 0 }
+        "LocalNetwork" { $value = 1 }
+        "Internet" { $value = 3 }
+    }
+
+    New-ItemProperty -LiteralPath $path1 -Name "DODownloadMode" -Value $value -PropertyType "DWord" -ErrorAction SilentlyContinue
+    Set-ItemProperty -LiteralPath $path1 -Name "DODownloadMode" -Value $value
+    # Unclear if we need that one as well. Test showed that not, but unclear of the consequences of diverging values
+    New-ItemProperty -LiteralPath $path2 -Name "SystemSettingsDownloadMode" -Value $value -PropertyType "DWord" -ErrorAction SilentlyContinue
+    Set-ItemProperty -LiteralPath $path2 -Name "SystemSettingsDownloadMode" -Value $value
+}

--- a/Web/WinConfig.cshtml
+++ b/Web/WinConfig.cshtml
@@ -16,6 +16,9 @@
 <h3>Disable-UAC</h3>
 <p>Disables UAC. Note that Windows 8 and 8.1 can not launch Windows Store applications with UAC disabled.</p>
 
+<h3>Set-UpdatesDeliveryMode</h3>
+<p>Sets the mode in which Updates are delivered. Allows to set the Update Bandwith Sharing option.</p>
+
 <h3>Enable-RemoteDesktop</h3>
 <p>Allows Remote Desktop access to machine and enables Remote Desktop firewall rule.</p>
 


### PR DESCRIPTION
Allows to define the delivery mode of updates and whether the P2P
feature of getting and sending updates from other PCs should be used or
not.