### PR TITLE
Disable-BingSearch

### DIFF
--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -1,4 +1,22 @@
 Resolve-Path $PSScriptRoot\*.ps1 | 
     % { . $_.ProviderPath }
 
-Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions
+Export-ModuleMember `
+    Disable-UAC, `
+    Enable-UAC, `
+    Get-UAC, `
+    Disable-InternetExplorerESC, `
+    Get-ExplorerOptions, `
+    Set-TaskbarSmall, `
+    Install-WindowsUpdate, `
+    Move-LibraryDirectory, `
+    Enable-RemoteDesktop, `
+    Set-ExplorerOptions, `
+    Get-LibraryNames, `
+    Update-ExecutionPolicy, `
+    Enable-MicrosoftUpdate, `
+    Disable-MicrosoftUpdate, `
+    Set-StartScreenOptions, `
+    Set-CornerNavigationOptions, `
+    Set-WindowsExplorerOptions, `
+    Set-TaskbarOptions

--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -6,6 +6,7 @@ Export-ModuleMember `
     Enable-UAC, `
     Get-UAC, `
     Disable-InternetExplorerESC, `
+    Disable-BingSearch, `
     Get-ExplorerOptions, `
     Set-TaskbarSmall, `
     Install-WindowsUpdate, `

--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.pssproj
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.pssproj
@@ -31,6 +31,7 @@
     <Compile Include="Boxstarter.WinConfig.psm1" />
     <Compile Include="Disable-InternetExplorerESC.ps1" />
     <Compile Include="Disable-UAC.ps1" />
+    <Compile Include="Disable-BingSearch.ps1" />
     <Compile Include="Enable-RemoteDesktop.ps1" />
     <Compile Include="Enable-UAC.ps1" />
     <Compile Include="Get-LibraryNames.ps1" />

--- a/Boxstarter.WinConfig/Disable-BingSearch.ps1
+++ b/Boxstarter.WinConfig/Disable-BingSearch.ps1
@@ -1,0 +1,19 @@
+function Disable-BingSearch {
+<#
+.SYNOPSIS
+Disables the Bing Internet Search when searching from the search field in the Taskbar or Start Menu.
+
+.LINK
+http://boxstarter.org
+https://www.privateinternetaccess.com/forum/discussion/18301/how-to-uninstall-core-apps-in-windows-10-and-miscellaneous
+
+#>
+    $path = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search"
+
+    if(!(Test-Path $path)) {
+        New-Item $path
+    }
+
+    New-ItemProperty -LiteralPath $path -Name "BingSearchEnabled" -Value 0 -PropertyType "DWord" -ErrorAction SilentlyContinue
+    Set-ItemProperty -LiteralPath $path -Name "BingSearchEnabled" -Value 0
+}

--- a/Web/WinConfig.cshtml
+++ b/Web/WinConfig.cshtml
@@ -16,6 +16,9 @@
 <h3>Disable-UAC</h3>
 <p>Disables UAC. Note that Windows 8 and 8.1 can not launch Windows Store applications with UAC disabled.</p>
 
+<h3>Disable-BingSearch</h3>
+<p>Disables the Bing Internet Search when searching from the search field in the Taskbar or Start Menu.</p>
+
 <h3>Enable-RemoteDesktop</h3>
 <p>Allows Remote Desktop access to machine and enables Remote Desktop firewall rule.</p>
 


### PR DESCRIPTION
Disables the Bing Internet Search when searching from the search field
in the Taskbar or Start Menu.