### PR TITLE
#116 - Added docs on how to execute a single text file using the WebLauncher

### DIFF
--- a/Web/WebLauncher.cshtml
+++ b/Web/WebLauncher.cshtml
@@ -39,7 +39,7 @@ cinst IIS-WebServerRole -source windowsfeatures
 <h4><span class="text-primary">Save your script</span></h4>
 <p>You have lots of options here. Boxstarter supports:</p>
 <ul>
-<li>Saving to as a package on any Nuget feed.</li>
+<li>Saving as a package to any Nuget feed.</li>
 <li>Saving a package to a Network share or any local media such as a thumb drive.</li>
 <li>Saving to a single text file or any text based HTTP resource (like a <a href="https://gist.github.com/">Github Gist</a>)</li>
 </ul>
@@ -64,6 +64,11 @@ START http://boxstarter.org/package/nr/url?https://gist.github.com/mwrock/738288
 <p>Note this URL is a simple Boxstarter URL: http://boxstarter.org/package/nr/url. The /nr/ tells Boxstarter not to reboot the machine. Depending on what you are installing, you may not want to include that. Especially if you are including more heavy weight applications, frameworks or Windows Updates.</p>
 
 <p>We add our raw Gist URL to the Boxstarter URL separated by a '?'.</p>
+
+<p>Additionally, if the script is saved locally to a single text file, the path can be added to the Boxstarter URL, again separated by a '?'.</p>
+<pre>
+START http://boxstarter.org/package/nr/url?c:\temp\myscript.txt
+</pre>
 
 <p>This invokes a Boxstarter installer that will install everything according to your script. </p>
 <img src="images\install.png"/>


### PR DESCRIPTION
As per #116 - Minor documentation typo fix and added instruction on how to execute a single text file using the WebLauncher