### PR TITLE
Replace dropped ending doublequote

### DIFF
--- a/BuildScripts/bootstrapper.ps1
+++ b/BuildScripts/bootstrapper.ps1
@@ -21,7 +21,7 @@ function Get-Boxstarter {
             # if there is no -v then its an older version with no -y
             $command = "cinst Boxstarter"
         }
-        $command += " -version 2.6.20
+        $command += " -version 2.6.20"
         Invoke-Expression $command
         $Message = "Boxstarter Module Installer completed"
     }


### PR DESCRIPTION
Recent commit to the bootstrapper dropped an ending doublequote causing the bootstrapper in mwrock/packer-templates to fail.  This PR fixes the problem.