### PR TITLE
Added [int64] check to ConvertTo-PSString

### DIFF
--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -419,7 +419,7 @@ function Import-BoxstarterVars {
 }
 
 function ConvertTo-PSString($originalValue) {
-    if($originalValue -is [int]){
+    if($originalValue -is [int] -or $originalValue -is [int64]){
         "$originalValue"
     }
     elseif($originalValue -is [Array]){


### PR DESCRIPTION
I ran into this Int64 error message when trying to install visual studio 2015 (a local package, not one on chocolatey.org). I'm not exactly sure if the error is actually associated with the install, but it seemed like the fix was to add a secondary check in ConvertTo-PSString to look for [int64] types.


![image](https://cloud.githubusercontent.com/assets/169953/14400864/587f9f26-fdb4-11e5-84f1-1877beea1b96.png)
