### PR TITLE
Fix for Test-PendingReboot not returning result of Get-PendingReboot.

### DIFF
--- a/Boxstarter.Bootstrapper/Test-PendingReboot.ps1
+++ b/Boxstarter.Bootstrapper/Test-PendingReboot.ps1
@@ -23,17 +23,15 @@ about_boxstarter_bootstrapper
 
 #>
     Write-BoxstarterMessage "Checking for Pending reboot" -Verbose
-    $rebootPending = $null
-    Remove-BoxstarterError {
+    return Remove-BoxstarterError {
         $rebootPending = Get-PendingReboot -ErrorLog $BoxStarter.Log
+		if ($rebootPending.RebootPending) {
+			Write-BoxstarterMessage "Detected Pending reboot" -Verbose
+			Log-BoxstarterMessage "$rebootPending"
+			return $true
+		}
+		else {
+			return $false
+		}
     }
-    if ($rebootPending.RebootPending) {
-        Write-BoxstarterMessage "Detected Pending reboot" -Verbose
-        Log-BoxstarterMessage "$rebootPending"
-        return $true
-    }
-    else {
-        return $false
-    }
-    
 }

--- a/tests/Bootstrapper/Test-PendingReboot.tests.ps1
+++ b/tests/Bootstrapper/Test-PendingReboot.tests.ps1
@@ -1,0 +1,40 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+if(get-module Boxstarter.bootstrapper){Remove-Module boxstarter.bootstrapper}
+Resolve-Path $here\..\..\boxstarter.common\*.ps1 | 
+    % { . $_.ProviderPath }
+Resolve-Path $here\..\..\boxstarter.winconfig\*.ps1 | 
+    % { . $_.ProviderPath }
+Resolve-Path $here\..\..\boxstarter.bootstrapper\*.ps1 | 
+    % { . $_.ProviderPath }
+$Boxstarter.SuppressLogging=$true
+$Boxstarter.BaseDir=(split-path -parent (split-path -parent $here))
+
+Describe "Test-PendingReboot" {
+    $testRoot = (Get-PSDrive TestDrive).Root
+   
+	Context "When reboot is required" {
+		Mock Get-PendingReboot { return new-Object -TypeName PSObject -Property @{ RebootPending=$True} }
+        $reboot = Test-PendingReboot
+
+        it "has invoked the Get-PendingReboot" {
+            Assert-MockCalled Get-PendingReboot
+        }
+
+		it "will return true" {
+			$reboot | should be $true
+		}
+    }
+
+	Context "When reboot is NOT required" {
+		Mock Get-PendingReboot { return new-Object -TypeName PSObject -Property @{ RebootPending=$False} }   
+        $reboot = Test-PendingReboot
+
+        it "has invoked the Get-PendingReboot" {
+            Assert-MockCalled Get-PendingReboot
+        }
+
+		it "will return true" {
+			$reboot | should be $false
+		}
+    }
+}

--- a/tests/Tests.pssproj
+++ b/tests/Tests.pssproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Azure\" />
+    <Folder Include="Bootstrapper\" />
     <Folder Include="Chocolatey\" />
     <Folder Include="Common\" />
     <Folder Include="HyperV\" />
@@ -47,6 +48,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Azure\Enable-BoxstarterVM.Tests.ps1" />
+    <Compile Include="Bootstrapper\Test-PendingReboot.tests.ps1" />
+    <Compile Include="Bootstrapper\Invoke-BoxStarter.tests.ps1" />
+    <Compile Include="Bootstrapper\Invoke-Reboot.tests.ps1" />
     <Compile Include="Chocolatey\Chocolatey.tests.ps1" />
     <Compile Include="Chocolatey\Enable-BoxstarterClientRemoting.Tests.ps1" />
     <Compile Include="Chocolatey\Get-BoxstarterConfig.tests.ps1" />


### PR DESCRIPTION
Moved the check on the result inside the scriptblock because the parent scope variable was not updated inside the Invoke-Command.

Included a test to prove the result