### PR TITLE
fix default value for RebootOk

### DIFF
--- a/Boxstarter.Bootstrapper/Invoke-Boxstarter.ps1
+++ b/Boxstarter.Bootstrapper/Invoke-Boxstarter.ps1
@@ -70,7 +70,9 @@ Invoke-Reboot
       [Parameter(Position=5,Mandatory=0)]
       [switch]$NoPassword,
       [Parameter(Position=6,Mandatory=0)]
-      [switch]$DisableRestart
+      [switch]$DisableRestart,
+      [Parameter(Position=7,Mandatory=0)]
+      [switch]$Shutdown
     )
     $BoxStarter.IsRebooting = $false
     $scriptFile = "$(Get-BoxstarterTempDir)\boxstarter.script"
@@ -92,6 +94,7 @@ Invoke-Reboot
         $session=Start-TimedSection "Installation session." -Verbose
         if($RebootOk){$Boxstarter.RebootOk=$RebootOk}
         if($DisableRestart){$Boxstarter.DisableRestart=$DisableRestart}
+		if($Shutdown){$Boxstarter.Shutdown=$Shutdown}
         if($encryptedPassword){$password = ConvertTo-SecureString -string $encryptedPassword}
         if(!$NoPassword){
             Write-BoxstarterMessage "NoPassword is false checking autologin" -verbose
@@ -114,6 +117,10 @@ Invoke-Reboot
     finally{
         Cleanup-Boxstarter -KeepWindowOpen:$KeepWindowOpen -DisableRestart:$DisableRestart
         Stop-TimedSection $session
+
+		if($BoxStarter.Shutdown) {
+			Stop-Computer -Force
+		}
         if($BoxStarter.IsRebooting) {
             RestartNow
         }

--- a/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
+++ b/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
@@ -278,7 +278,8 @@ about_boxstarter_chocolatey
         [parameter(ParameterSetName="Package")]
         [switch]$KeepWindowOpen,
         [string]$LocalRepo,
-        [switch]$DisableRestart
+        [switch]$DisableRestart,
+		[switch]$Shutdown
     )
     $CurrentVerbosity=$global:VerbosePreference
     try {
@@ -519,7 +520,8 @@ function Invoke-Locally {
         [switch]$DisableReboots,
         [switch]$KeepWindowOpen,
         [switch]$DisableRestart,
-        [string]$LocalRepo
+        [string]$LocalRepo,
+		[switch]$Shutdown
     )
     if($PSBoundParameters.ContainsKey("Credential")){
         if($Credential -ne $null) {

--- a/Boxstarter.Chocolatey/Invoke-ChocolateyBoxstarter.ps1
+++ b/Boxstarter.Chocolatey/Invoke-ChocolateyBoxstarter.ps1
@@ -124,6 +124,7 @@ Set-BoxstarterConfig
       [switch]$DisableRestart
     )
     try{
+		$Boxstarter.RebootOk=$true
         if($DisableReboots){
             Write-BoxstarterMessage "Disabling reboots" -Verbose
             $Boxstarter.RebootOk=$false

--- a/Boxstarter.Chocolatey/Invoke-ChocolateyBoxstarter.ps1
+++ b/Boxstarter.Chocolatey/Invoke-ChocolateyBoxstarter.ps1
@@ -121,7 +121,8 @@ Set-BoxstarterConfig
       [System.Security.SecureString]$Password,
       [switch]$KeepWindowOpen,
       [switch]$NoPassword,
-      [switch]$DisableRestart
+      [switch]$DisableRestart,
+      [switch]$Shutdown
     )
     try{
 		$Boxstarter.RebootOk=$true

--- a/tests/Bootstrapper/Invoke-BoxStarter.tests.ps1
+++ b/tests/Bootstrapper/Invoke-BoxStarter.tests.ps1
@@ -483,4 +483,14 @@ Describe "Invoke-Boxstarter" {
             Assert-MockCalled New-Item -ParameterFilter {$path -like "*ReEnableUac*"} -times 0
         }
     }
+
+	Context "When Shutdown is enabled" {
+		Mock Stop-Computer
+		Invoke-Boxstarter {return} -Shutdown | Out-Null
+
+		It "will invoke a shutdown when finished" {
+			Assert-MockCalled Stop-Computer
+		}
+
+	}
 }

--- a/tests/Chocolatey/Install-BoxstarterPackage.tests.ps1
+++ b/tests/Chocolatey/Install-BoxstarterPackage.tests.ps1
@@ -567,4 +567,13 @@ Describe "Install-BoxstarterPackage" {
             $result.Completed | should be $false
         }
     }
+
+	Context "When shutdown is enabled" {
+		Mock Invoke-ChocolateyBoxstarter
+		Install-BoxstarterPackage -PackageName test-package3 -Shutdown
+
+		It "should be passed on" {
+			Assert-MockCalled Invoke-ChocolateyBoxstarter -ParameterFilter { $Shutdown -eq $true }
+		}
+	}
 }

--- a/tests/Chocolatey/Invoke-ChocolateyBoxstarter.tests.ps1
+++ b/tests/Chocolatey/Invoke-ChocolateyBoxstarter.tests.ps1
@@ -155,5 +155,22 @@ Describe "Invoke-ChocolateyBoxstarter" {
             Assert-MockCalled chocolatey -ParameterFilter { (Compare-Object $packageNames $packages) -eq $null }
         }
     }
+	
+    Context "When DisableReboots switch absent"{
+        Mock Invoke-Boxstarter
+		Invoke-ChocolateyBoxstarter test-package3 | Out-Null
+		
+		It "should enable RebootOk when invoking Boxstarter" {
+			Assert-MockCalled Invoke-Boxstarter -ParameterFilter {$RebootOk -eq $true}
+		}
+    }
 
+    Context "When DisableReboots switch enabled"{
+        Mock Invoke-Boxstarter
+		Invoke-ChocolateyBoxstarter test-package3 -DisableReboots | Out-Null
+		
+		It "should disable RebootOk when invoking Boxstarter" {
+			Assert-MockCalled Invoke-Boxstarter -ParameterFilter {$RebootOk -eq $false}
+		}
+    }
 }

--- a/tests/Chocolatey/Invoke-ChocolateyBoxstarter.tests.ps1
+++ b/tests/Chocolatey/Invoke-ChocolateyBoxstarter.tests.ps1
@@ -173,4 +173,13 @@ Describe "Invoke-ChocolateyBoxstarter" {
 			Assert-MockCalled Invoke-Boxstarter -ParameterFilter {$RebootOk -eq $false}
 		}
     }
+
+	Context "When Shutdown switch enabled" {
+		Mock Invoke-Boxstarter
+		Invoke-ChocolateyBoxstarter test-package3 -Shutdown | Out-Null
+
+		It "should pass shutdown on to Invoke-Boxstarter" {
+			Assert-MockCalled Invoke-Boxstarter -ParameterFilter {Shutdown -eq $true}
+		}
+	}
 }


### PR DESCRIPTION
From my observations RebootOk was always initialized to $false so there was no way to override this behaviour when calling Install-BoxstarterPackage. 

See [this](https://github.com/mwrock/boxstarter/commit/22a7bfa9976d505bb7acb5fddec1dd2d79aeb15b#commitcomment-17285254) discussion where the regression was introduced.

I added a test to prove this behaviour and suggested a fix.
