### PR TITLE
Choco0.10.3

### DIFF
--- a/Boxstarter.Chocolatey/Boxstarter.Chocolatey.pssproj
+++ b/Boxstarter.Chocolatey/Boxstarter.Chocolatey.pssproj
@@ -64,6 +64,7 @@
     <Compile Include="Get-PackageRoot.ps1" />
     <Compile Include="Install-BoxstarterPackage.ps1" />
     <Compile Include="Invoke-BoxstarterBuild.ps1" />
+    <Compile Include="invoke-chocolatey.ps1" />
     <Compile Include="Invoke-ChocolateyBoxstarter.ps1" />
     <Compile Include="New-BoxstarterPackage.ps1" />
     <Compile Include="New-PackageFromScript.ps1" />

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -89,6 +89,12 @@ namespace Boxstarter
 
         public void Info(string message, params object[] formatting)
         {
+			if (message.StartsWith("VERBOSE: "))
+			{
+				Debug(message, formatting);
+				return;
+			}
+
             WriteLog(
                 message,
                 x => {
@@ -236,7 +242,7 @@ namespace Boxstarter
         Write-BoxstarterMessage "instantiating choco wrapper..." -Verbose
         $global:choco = New-Object -TypeName boxstarter.ChocolateyWrapper -ArgumentList `
           (Get-BoxstarterSetup),`
-          ($global:DebugPreference -eq "Continue"),`
+          $false,`
           $boxstarter.log,`
           $boxstarter.SuppressLogging
     }

--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -228,13 +228,21 @@ task Install-WebDeploy {
 }
 
 task Install-ChocoLib {
-    exec { .$nugetExe install chocolatey.lib -Version 0.9.10-beta-20151210 -Pre -OutputDirectory $basedir\Boxstarter.Chocolatey\ }
-    exec { .$nugetExe install log4net -Version 2.0.3 -OutputDirectory $basedir\Boxstarter.Chocolatey\ }
-    MkDir $basedir\Boxstarter.Chocolatey\chocolatey -ErrorAction SilentlyContinue
-    Copy-Item $basedir\Boxstarter.Chocolatey\log4net.2.0.3\lib\net40-full\* $basedir\Boxstarter.Chocolatey\chocolatey
-    Copy-Item $basedir\Boxstarter.Chocolatey\chocolatey.lib.0.9.10-beta-20151210\lib\* $basedir\Boxstarter.Chocolatey\chocolatey
-    Remove-Item $basedir\Boxstarter.Chocolatey\log4net.2.0.3 -Recurse -Force
-    Remove-Item $basedir\Boxstarter.Chocolatey\chocolatey.lib.0.9.10-beta-20151210 -Recurse -Force
+	$project = Join-Path $basedir "Boxstarter.Chocolatey"
+	$temp = Join-Path $project "temp"
+
+    exec { .$nugetExe install chocolatey.lib -Version 0.10.3 -OutputDirectory $temp }
+    exec { .$nugetExe install alphafs -Version 2.0.0 -OutputDirectory $temp }
+
+	$output = Join-Path $project "chocolatey"
+	Remove-Item $output -Force -Recurse
+    New-Item $output -ItemType Directory
+
+    Copy-Item $temp\log4net.*\lib\net40-full\* $output
+    Copy-Item $temp\chocolatey.lib.*\lib\* $output
+	Copy-Item $temp\alphafs.*\lib\net451\* $output
+    
+	Remove-Item $temp -Recurse -Force
 }
 
 function PackDirectory($path, [switch]$AddReleaseNotes){

--- a/tests/Chocolatey/Invoke-Chocolatey.tests.ps1
+++ b/tests/Chocolatey/Invoke-Chocolatey.tests.ps1
@@ -1,0 +1,71 @@
+﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+if(get-module Boxstarter.Chocolatey){Remove-Module boxstarter.Chocolatey}
+Resolve-Path $here\..\..\Boxstarter.Common\*.ps1 | 
+    % { . $_.ProviderPath }
+Resolve-Path $here\..\..\Boxstarter.Bootstrapper\*.ps1 | 
+    % { . $_.ProviderPath }
+
+$Boxstarter.BaseDir=(split-path -parent (split-path -parent $here))
+$Boxstarter.SuppressLogging=$true
+Resolve-Path $here\..\..\Boxstarter.Chocolatey\*.ps1 | 
+    % { . $_.ProviderPath }
+
+
+# When you change the ChocolateyWrapper type you'll get this error for a
+# subsequent test run:
+# > Cannot add type. The type name 'Boxstarter.ChocolateyWrapper' already exists.
+# You'll have to kill the testrunner to solve this.
+# Package Manager Console: 
+#   Get-Process -Name vstest.executionengine.x86 | Stop-Process
+Describe "Invoke-Chocolatey" {
+	$global:choco = $null
+
+	Context "adds chocolatey wrapper types" {
+		Mock Write-BoxstarterMessage
+		Mock Enter-BoxstarterLogable
+
+		Invoke-Chocolatey -chocoArgs "--version"
+
+		it "has message written" {
+			Assert-MockCalled Write-BoxstarterMessage -ParameterFilter { $message -eq "Types added..." }
+		}
+	}
+
+	Context "invokes created type" {
+		Invoke-Chocolatey -chocoArgs "--version"
+	}
+
+	Context "subsequent calls" {
+		$global:choco = $null
+		Invoke-Chocolatey -chocoArgs "--version"
+
+		$global:choco = $null
+		Invoke-Chocolatey -chocoArgs "--version"
+	}
+
+	Context "logger" {
+		# Just invoke to make sure the types are created and loaded.
+		Invoke-Chocolatey -chocoArgs "--version"
+
+		$logfile = Join-Path $env:TEMP "test.log"
+		$log = New-Object -TypeName boxstarter.PsLogger -ArgumentList `
+			$true,`
+			$logfile,`
+			$false
+
+		$log.Debug("output {0}", "debug")
+		$log.Debug({ "debug" });
+		$log.Info("output {0}", "info")
+		$log.Info({ "info" });
+		$log.Warn("output {0}", "warn")
+		$log.Warn({ "warn" });
+		$log.Error("output {0}", "error")
+		$log.Error({ "error" });
+		$log.Fatal("output {0}", "fatal")
+		$log.Fatal({ "fatal" });
+
+		it "has written to file" {
+			Test-Path -Path $logfile | Should Be $true
+		}
+	}
+}

--- a/tests/Tests.pssproj
+++ b/tests/Tests.pssproj
@@ -62,6 +62,7 @@
     <Compile Include="Chocolatey\New-PackageFromScript.tests.ps1" />
     <Compile Include="Chocolatey\Set-BoxstarterShare.Tests.ps1" />
     <Compile Include="Common\Invoke-FromTask.tests.ps1" />
+    <Compile Include="Chocolatey\Invoke-Chocolatey.tests.ps1" />
     <Compile Include="TestRunner\Install-BoxstarterScripts.tests.ps1" />
     <Compile Include="TestRunner\Set-BoxstarterFeedAPIKey.Tests.ps1" />
   </ItemGroup>


### PR DESCRIPTION
Updated the chocolatey lib to 0.10.3.

Things I had to fix:

- Initialisation of the ChocolateyWrapper
- Output of the PsLogger
- Redirect of Verbose messages that (accidentally) were invoked on the Info method

Currently there are still some things up for improvement: 

- Duplicate lines in the output, especially warnings (probably related: https://github.com/mwrock/boxstarter/issues/80)

But at least this update fixes a handful of open compatibility issues with newer versions of chocolatey:

- https://github.com/mwrock/boxstarter/issues/186
- https://github.com/mwrock/boxstarter/issues/148
- Probably https://github.com/mwrock/boxstarter/issues/198