### PR TITLE
Add required tags element to BoxStarter.Common nuspec

### DIFF
--- a/BuildScripts/nuget/Boxstarter.Common.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Common.nuspec
@@ -11,6 +11,7 @@
     <title>Boxstarter Common Module</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Provides common functions used by multiple Boxstarter Modules.</description>
+    <tags>boxstarter</tags>
     <releaseNotes xmlns="">
 - Update vendored chocolatey to stable 0.10.4
 - Randomize package names generated from script to avoid file locks


### PR DESCRIPTION
Boxstarter.Common 2.9.5 was [marked as rejected](https://chocolatey.org/packages/BoxStarter.Common/2.9.5) on Chocolatey. This breaks the Boxstarter bootstrapper, as Boxstarter.Common >= 2.9.5 is a dependency of the Boxstarter package.

This commit adds the [required](https://github.com/chocolatey/package-validator/wiki/TagsNotEmpty) _tags_ element to the nuspec.