### PR TITLE
Fix InstallBoxstarter dead link

### DIFF
--- a/Web/Learn/SimplePackage.cshtml
+++ b/Web/Learn/SimplePackage.cshtml
@@ -13,7 +13,7 @@
 <h4><span class="text-primary">Install Boxstarter</span></h4>
 <p>If you have Chocolatey:</p>
 <pre>CINST Boxstarter</pre>
-<p>Otherwise, click on the download link at the top of this page and run the Setup.bat file. See <a href="InstallBoxstarter">Installing Boxstarter</a> for details.</p>
+<p>Otherwise, click on the download link at the top of this page and run the Setup.bat file. See <a href="~/InstallBoxstarter">Installing Boxstarter</a> for details.</p>
 
 <h3>Step 2</h3>
 <h4><span class="text-primary">Create your installer script</span></h4>


### PR DESCRIPTION
It was incorrectly pointing at `Learn/InstallBoxstarter`, which does not exist.