### PR TITLE
(GH-382) Chocolatey wrapper to quickly exit and report errors to callers

### DIFF
--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -56,6 +56,7 @@ Intercepts Chocolatey call to check for reboots
         [string[]]$packageNames=@('')
     )
     chocolatey Install @PSBoundParameters @args
+    return $LastExitCode
 }
 
 function choco {
@@ -69,6 +70,7 @@ Intercepts Chocolatey call to check for reboots
         [string[]]$packageNames=@('')
     )
     chocolatey @PSBoundParameters @args
+    return $LastExitCode
 }
 
 function cup {
@@ -81,6 +83,7 @@ Intercepts Chocolatey call to check for reboots
         [string[]]$packageNames=@('')
     )
     chocolatey Update @PSBoundParameters @args
+    return $LastExitCode
 }
 
 function chocolatey {
@@ -159,6 +162,9 @@ Intercepts Chocolatey call to check for reboots
                     if($RebootCodes -contains $errorCode) {
                        Write-BoxstarterMessage "Chocolatey Install returned a rebootable exit code" -verbose
                        $rebootable = $true
+                    } else {
+                        Write-BoxStarterMessage "Exiting..."
+                        return 1
                     }
                 }
                 $idx += 1
@@ -170,6 +176,7 @@ Intercepts Chocolatey call to check for reboots
             Invoke-Reboot
         }
     }
+    return 0
 }
 
 function Get-PassedArg($argName, $origArgs) {


### PR DESCRIPTION
This feature is useful when the callers want to make sure all packages are installed successfully before continuing to the next. 