### PR TITLE
(GH-347) Removing PowerShell Aliases

### DIFF
--- a/BuildScripts/build.ps1
+++ b/BuildScripts/build.ps1
@@ -7,7 +7,7 @@ param (
 )
 $here = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 if(-not $env:ChocolateyInstall -or -not (Test-Path "$env:ChocolateyInstall")){
-    iex ((new-object net.webclient).DownloadString("https://bit.ly/psChocInstall"))
+    Invoke-Expression ((new-object net.webclient).DownloadString("https://bit.ly/psChocInstall"))
 }
 
 if(!(Test-Path $env:ChocolateyInstall\lib\Psake*)) { cinst psake -y --no-progress }
@@ -26,8 +26,8 @@ if($Help){
   return
 }
 
-$psakeDir = (dir $env:ChocolateyInstall\lib\Psake*)
-if($psakeDir.length -gt 0) {$psakerDir = $psakeDir[-1]}
+$psakeDir = (Get-ChildItem $env:ChocolateyInstall\lib\Psake*)
+if($psakeDir.length -gt 0) {$psakeDir = $psakeDir[-1]}
 ."$psakeDir\tools\psake\psake.ps1" "$here/default.ps1" $Action -ScriptPath $psakeDir\tools\psake -parameters $PSBoundParameters
 
 if($psake.build_success -eq $false) {

--- a/BuildScripts/setup.ps1
+++ b/BuildScripts/setup.ps1
@@ -7,7 +7,7 @@ function Install-Boxstarter($here, $ModuleName, $installArgs = "") {
     if(!(test-Path $packagePath)){
         mkdir $packagePath
     }
-    foreach($ModulePath in (Get-ChildItem $here | ?{ $_.PSIsContainer })){
+    foreach($ModulePath in (Get-ChildItem $here | Where-Object { $_.PSIsContainer })){
         $target=Join-Path $boxstarterPath $modulePath.BaseName
         if(test-Path $target){
             Remove-Item $target -Recurse -Force
@@ -113,7 +113,7 @@ function PersistBoxStarterPathToEnvironmentVariable($variableName, $boxstarterPa
     # Remove user scoped vars from previous releases
     $userValue = [Environment]::GetEnvironmentVariable($variableName, 'User')
     if($userValue){
-        $userValues=($userValue -split ';' | ?{ !($_.ToLower() -match "\\boxstarter$")}) -join ';'
+        $userValues=($userValue -split ';' | Where-Object { !($_.ToLower() -match "\\boxstarter$")}) -join ';'
     }
     elseif($variableName -eq "PSModulePath") {
         $userValues = [environment]::getfolderpath("mydocuments")
@@ -123,7 +123,7 @@ function PersistBoxStarterPathToEnvironmentVariable($variableName, $boxstarterPa
 
     $value = [Environment]::GetEnvironmentVariable($variableName, 'Machine')
     if($value){
-        $values=($value -split ';' | ?{ !($_.ToLower() -match "\\boxstarter$")}) -join ';'
+        $values=($value -split ';' | Where-Object { !($_.ToLower() -match "\\boxstarter$")}) -join ';'
         $values="$boxstarterPath;$values"
     }
     elseif($variableName -eq "PSModulePath") {


### PR DESCRIPTION
- a partial fix for #347 
- also fix variable name `psakerDir`
- remove version for Pester (doesn't seem to mind running latest version)
