### PR TITLE
(#477) Uploads Artifacts after Build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,3 +17,7 @@ branches:
     - master
     - /release/.*/
     - /hotfix/.*/
+
+artifacts:
+  - path: '.\BuildArtifacts\Boxstarter.*.zip'
+  - path: '.\BuildArtifacts\Boxstarter.*.nupkg'


### PR DESCRIPTION
## Description
This PR should result in the main artifacts (namely the Boxstarter zip and nupkg) being published to AppVeyor after the build has completed.

This will allow folk to use them for testing.

## Related Issue
Fixes #477

## Motivation and Context
It seems reasonable to have artifacts published available from all builds.

## How Has This Been Tested?
This is where this falls down a bit - I'm unsure I'm able to test this without further modifying the `.appveyor.yml` file to run on additional branches.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
