### PR TITLE
(GH-394) chocolatey.dll no more

### DIFF
--- a/BoxStarter.Common/Boxstarter.Common.psm1
+++ b/BoxStarter.Common/Boxstarter.Common.psm1
@@ -19,6 +19,7 @@ Export-ModuleMember Confirm-Choice,`
                     Stop-TimedSection,`
                     Test-Admin,`
                     Write-BoxstarterLogo,`
-                    Write-BoxstarterMessage
+                    Write-BoxstarterMessage,`
+                    Get-BoxstarterTaskContextTempDir
 
 Export-ModuleMember -Variable Boxstarter

--- a/BoxStarter.Common/Create-BoxstarterTask.ps1
+++ b/BoxStarter.Common/Create-BoxstarterTask.ps1
@@ -24,10 +24,10 @@ Remove-BoxstarterTask
         if($Credential.GetNetworkCredential().Password.length -gt 0){
             schtasks /CREATE /TN 'Temp Boxstarter Task' /SC WEEKLY /RL HIGHEST `
                 /RU "$($Credential.UserName)" /IT /RP $Credential.GetNetworkCredential().Password `
-            /TR "powershell -noprofile -ExecutionPolicy Bypass -File $env:temp\BoxstarterTask.ps1" /F | Out-Null
+            /TR "powershell -noprofile -ExecutionPolicy Bypass -File $(Get-BoxstarterTaskContextTempDir)\BoxstarterTask.ps1" /F | Out-Null
 
             #Give task a normal priority
-            $taskFile = Join-Path $env:TEMP RemotingTask.txt
+            $taskFile = Join-Path $(Get-BoxstarterTaskContextTempDir) RemotingTask.txt
             Remove-Item $taskFile -Force -ErrorAction SilentlyContinue
             [xml]$xml = schtasks /QUERY /TN 'Temp Boxstarter Task' /XML
             if($xml.Task.Settings.Priority -eq $null) {
@@ -42,7 +42,7 @@ Remove-BoxstarterTask
         elseif(!((schtasks /QUERY /TN 'Boxstarter Task' /FO LIST 2>&1) -contains 'Logon Mode:    Interactive/Background')) { #For testing
             schtasks /CREATE /TN 'Boxstarter Task' /SC WEEKLY /RL HIGHEST `
                     /RU "$($Credential.UserName)" /IT `
-            /TR "powershell -noprofile -ExecutionPolicy Bypass -File $env:temp\BoxstarterTask.ps1" /F |
+            /TR "powershell -noprofile -ExecutionPolicy Bypass -File $(Get-BoxstarterTaskContextTempDir)\BoxstarterTask.ps1" /F |
                     Out-Null
         }
     }

--- a/BoxStarter.Common/Get-BoxstarterTaskContextTempDir.ps1
+++ b/BoxStarter.Common/Get-BoxstarterTaskContextTempDir.ps1
@@ -1,0 +1,15 @@
+
+function Get-BoxstarterTaskContextTempDir {
+    $sysTemp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
+    $stableTempDir = Join-Path $sysTemp "BoxstarterTemp"
+    if (-Not (Test-Path $stableTempDir)) {
+        try {
+            New-Item -ItemType Directory -Path $stableTempDir -Force | Out-Null
+        } 
+        catch {
+            Write-BoxstarterMessage "failed to create $stableTempDir"
+            throw
+        }
+    }
+    $stableTempDir
+}

--- a/Boxstarter.Bootstrapper/BoxStarter.Bootstrapper.psm1
+++ b/Boxstarter.Bootstrapper/BoxStarter.Bootstrapper.psm1
@@ -12,4 +12,4 @@ Export-ModuleMember Invoke-BoxStarter, `
                     Out-Boxstarter, `
                     Enter-BoxstarterLogable, `
                     Get-BoxstarterTempDir, `
-                    Setup-BoxstarterExtension
+                    Install-BoxstarterExtension

--- a/Boxstarter.Bootstrapper/BoxStarter.Bootstrapper.psm1
+++ b/Boxstarter.Bootstrapper/BoxStarter.Bootstrapper.psm1
@@ -11,4 +11,5 @@ Export-ModuleMember Invoke-BoxStarter, `
                     Stop-TimedSection, `
                     Out-Boxstarter, `
                     Enter-BoxstarterLogable, `
-                    Get-BoxstarterTempDir
+                    Get-BoxstarterTempDir, `
+                    Setup-BoxstarterExtension

--- a/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
+++ b/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
@@ -7,6 +7,22 @@ function Cleanup-Boxstarter {
     }
     Start-UpdateServices
 
+    $extensionBaseDir = "$env:ChocolateyInstall\extensions\boxstarter-choco"
+    if (Test-Path $extensionBaseDir) {
+        Remove-Item $extensionBaseDir -Recurse -Force -ErrorAction SilentlyContinue
+
+        Import-Module "$env:ChocolateyInstall/helpers/chocolateyProfile.psm1" -DisableNameChecking:$true
+        . "$env:ChocolateyInstall/helpers/functions/Write-FunctionCallLogMessage.ps1"
+        . "$env:ChocolateyInstall/helpers/functions/Test-ProcessAdminRights.ps1"
+        . "$env:ChocolateyInstall/helpers/functions/Set-EnvironmentVariable.ps1"
+        . "$env:ChocolateyInstall/helpers/functions/Uninstall-ChocolateyEnvironmentVariable.ps1"
+        $uninstallEnvVarParam = @{
+            variableName = 'BoxstarterChocoExtension'
+            variableType = [System.EnvironmentVariableTarget]::Machine
+        }
+        Uninstall-ChocolateyEnvironmentVariable @uninstallEnvVarParam
+    }
+
     if(Test-Path "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC") {
         del "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC"
         Enable-UAC

--- a/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
+++ b/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
@@ -10,17 +10,6 @@ function Cleanup-Boxstarter {
     $extensionBaseDir = "$env:ChocolateyInstall\extensions\boxstarter-choco"
     if (Test-Path $extensionBaseDir) {
         Remove-Item $extensionBaseDir -Recurse -Force -ErrorAction SilentlyContinue
-
-        Import-Module "$env:ChocolateyInstall/helpers/chocolateyProfile.psm1" -DisableNameChecking:$true
-        . "$env:ChocolateyInstall/helpers/functions/Write-FunctionCallLogMessage.ps1"
-        . "$env:ChocolateyInstall/helpers/functions/Test-ProcessAdminRights.ps1"
-        . "$env:ChocolateyInstall/helpers/functions/Set-EnvironmentVariable.ps1"
-        . "$env:ChocolateyInstall/helpers/functions/Uninstall-ChocolateyEnvironmentVariable.ps1"
-        $uninstallEnvVarParam = @{
-            variableName = 'BoxstarterChocoExtension'
-            variableType = [System.EnvironmentVariableTarget]::Machine
-        }
-        Uninstall-ChocolateyEnvironmentVariable @uninstallEnvVarParam
     }
 
     if(Test-Path "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC") {

--- a/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
+++ b/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
@@ -10,6 +10,7 @@ function Cleanup-Boxstarter {
     $extensionBaseDir = "$env:ChocolateyInstall\extensions\boxstarter-choco"
     if (Test-Path $extensionBaseDir) {
         Remove-Item $extensionBaseDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item "$(Join-Path $env:temp 'Boxstarter.ext.*')" -Force -ErrorAction SilentlyContinue
     }
 
     if(Test-Path "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC") {

--- a/Boxstarter.Bootstrapper/Install-BoxstarterExtension.ps1
+++ b/Boxstarter.Bootstrapper/Install-BoxstarterExtension.ps1
@@ -1,5 +1,5 @@
 
-function Setup-BoxstarterExtension {
+function Install-BoxstarterExtension {
     $extensionBaseDir = "$env:ChocolateyInstall\extensions\boxstarter-choco"
     New-Item -ItemType Directory -Path $extensionBaseDir -Force | Out-Null
 
@@ -8,8 +8,9 @@ function Setup-BoxstarterExtension {
 
 if (-Not (Test-Path `$testfile)) {
   New-Item -Path `$testfile | Out-Null
-  Write-Host "Lets.GetBoxstarter() :-)"        
+  Write-Host " *** LOADING BOXSTARTER ***"        
   Import-Module '$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.Chocolatey.psd1' -Global -DisableNameChecking -ArgumentList `$true
+  Write-BoxstarterMessage "*** HELLO WORLD ***"
 }
 "@ | Out-File "$extensionBaseDir/boxstarter-choco.psm1" -Encoding utf8
 

--- a/Boxstarter.Bootstrapper/Setup-BoxstarterExtension.ps1
+++ b/Boxstarter.Bootstrapper/Setup-BoxstarterExtension.ps1
@@ -1,0 +1,25 @@
+
+function Setup-BoxstarterExtension {
+    $extensionBaseDir = "$env:ChocolateyInstall\extensions\boxstarter-choco"
+    New-Item -ItemType Directory -Path $extensionBaseDir -Force | Out-Null
+
+    @"
+if (`$env:BoxstarterChocoExtension) {
+Write-Host "Lets.GetBoxstarter() :-)"        
+Import-Module '$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.Chocolatey.psd1' -DisableNameChecking -ArgumentList `$true
+Write-Host "Boxstarter superpowers initiated..."
+}
+"@ | Out-File "$extensionBaseDir/boxstarter-choco.psm1" -Encoding utf8
+
+    Import-Module "$env:ChocolateyInstall/helpers/chocolateyProfile.psm1" -DisableNameChecking:$true
+    . "$env:ChocolateyInstall/helpers/functions/Write-FunctionCallLogMessage.ps1"
+    . "$env:ChocolateyInstall/helpers/functions/Test-ProcessAdminRights.ps1"
+    . "$env:ChocolateyInstall/helpers/functions/Set-EnvironmentVariable.ps1"
+    . "$env:ChocolateyInstall/helpers/functions/Install-ChocolateyEnvironmentVariable.ps1"
+    $installEnvVarParam = @{
+        variableName  = 'BoxstarterChocoExtension'
+        variableValue = 'absolutely'
+        variableType  = [System.EnvironmentVariableTarget]::Machine
+    }
+    Install-ChocolateyEnvironmentVariable @installEnvVarParam
+}

--- a/Boxstarter.Bootstrapper/Setup-BoxstarterExtension.ps1
+++ b/Boxstarter.Bootstrapper/Setup-BoxstarterExtension.ps1
@@ -4,22 +4,8 @@ function Setup-BoxstarterExtension {
     New-Item -ItemType Directory -Path $extensionBaseDir -Force | Out-Null
 
     @"
-if (`$env:BoxstarterChocoExtension) {
 Write-Host "Lets.GetBoxstarter() :-)"        
 Import-Module '$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.Chocolatey.psd1' -DisableNameChecking -ArgumentList `$true
-Write-Host "Boxstarter superpowers initiated..."
-}
 "@ | Out-File "$extensionBaseDir/boxstarter-choco.psm1" -Encoding utf8
 
-    Import-Module "$env:ChocolateyInstall/helpers/chocolateyProfile.psm1" -DisableNameChecking:$true
-    . "$env:ChocolateyInstall/helpers/functions/Write-FunctionCallLogMessage.ps1"
-    . "$env:ChocolateyInstall/helpers/functions/Test-ProcessAdminRights.ps1"
-    . "$env:ChocolateyInstall/helpers/functions/Set-EnvironmentVariable.ps1"
-    . "$env:ChocolateyInstall/helpers/functions/Install-ChocolateyEnvironmentVariable.ps1"
-    $installEnvVarParam = @{
-        variableName  = 'BoxstarterChocoExtension'
-        variableValue = 'absolutely'
-        variableType  = [System.EnvironmentVariableTarget]::Machine
-    }
-    Install-ChocolateyEnvironmentVariable @installEnvVarParam
 }

--- a/Boxstarter.Bootstrapper/Setup-BoxstarterExtension.ps1
+++ b/Boxstarter.Bootstrapper/Setup-BoxstarterExtension.ps1
@@ -4,8 +4,13 @@ function Setup-BoxstarterExtension {
     New-Item -ItemType Directory -Path $extensionBaseDir -Force | Out-Null
 
     @"
-Write-Host "Lets.GetBoxstarter() :-)"        
-Import-Module '$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.Chocolatey.psd1' -DisableNameChecking -ArgumentList `$true
+`$testfile = '$(Join-Path $env:temp "Boxstarter.ext.$PID")'
+
+if (-Not (Test-Path `$testfile)) {
+  New-Item -Path `$testfile | Out-Null
+  Write-Host "Lets.GetBoxstarter() :-)"        
+  Import-Module '$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.Chocolatey.psd1' -Global -DisableNameChecking -ArgumentList `$true
+}
 "@ | Out-File "$extensionBaseDir/boxstarter-choco.psm1" -Encoding utf8
 
 }

--- a/Boxstarter.Chocolatey/BoxstarterConnectionConfig.ps1
+++ b/Boxstarter.Chocolatey/BoxstarterConnectionConfig.ps1
@@ -10,4 +10,6 @@ public class BoxstarterConnectionConfig {
     public System.Management.Automation.Remoting.PSSessionOption PSSessionOption;
 }
 "@
-Add-Type -TypeDefinition $source
+if (-Not ([System.Management.Automation.PSTypeName]'BoxstarterConnectionConfig').Type) {
+    Add-Type -TypeDefinition $source
+}

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -78,6 +78,9 @@ function Write-HostOverride {
     }
 }
 
+# TODO: check if this actually works the way I think it does!
+Import-Module $env:chocolateyinstall\helpers\chocolateyInstaller.psm1 -Global -DisableNameChecking
+
 new-alias Install-ChocolateyInstallPackage Install-ChocolateyInstallPackageOverride -force
 new-alias Write-Host Write-HostOverride -force
 

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -192,6 +192,11 @@ function chocolatey {
     Write-BoxstarterMessage "Installing $($PackageNames.Count) packages" -Verbose
 
     foreach ($packageName in $PackageNames) {
+        # cannot use boxstarter to install chocolatey since v3
+        if ('chocolatey' -eq $packageName) {
+            Write-BoxstarterMessage "Chocolatey cannot be installed/upgraded using Boxstarter." -color ([ConsoleColor]::Yellow)
+            continue
+        }
         $PSBoundParameters.PackageNames = $packageName
         if ((Get-PassedArg -ArgumentName @("source", "s") -OriginalArgs $args) -eq "WindowsFeatures") {
             $dismInfo = (DISM /Online /Get-FeatureInfo /FeatureName:$packageName)
@@ -513,7 +518,7 @@ function Format-ExeArgs {
 
         #$p = $p | ForEach-Object { "$($_)" }
         if ($p.StartsWith("'")) {
-          $p = "`"$p`""
+            $p = "`"$p`""
         }
         
         $newArgs += $p 

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -432,7 +432,7 @@ function Call-Chocolatey {
 
     $chocoArgs = @($Command, $PackageNames)
     $chocoArgs += Format-ExeArgs -Command $Command @args
-    $chocoArgsExpanded = $chocoArgs | Foreach-Object { "$($_); " }
+    $chocoArgsExpanded = $chocoArgs | Foreach-Object { "$($_)" }
     Write-BoxstarterMessage "Passing the following args to Chocolatey: @($chocoArgsExpanded)" -Verbose
 
     $currentLogging = $Boxstarter.Suppresslogging
@@ -441,10 +441,10 @@ function Call-Chocolatey {
             $Boxstarter.SuppressLogging = $true 
         }
         if (($PSVersionTable.CLRVersion.Major -lt 4 -or (Test-WindowsFeatureInstall $args)) -and (Get-IsRemote)) {
-            Invoke-ChocolateyFromTask $chocoArgs
+            Invoke-ChocolateyFromTask $chocoArgsExpanded
         }
         else {
-            Invoke-LocalChocolatey $chocoArgs
+            Invoke-LocalChocolatey $chocoArgsExpanded
         }
     }
     finally {

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -79,7 +79,11 @@ function Write-HostOverride {
 }
 
 # Need to import the module _BEFORE_ we use an alias to override the core func
-Import-Module $env:chocolateyinstall\helpers\chocolateyInstaller.psm1 -Global -DisableNameChecking
+if ($env:chocolateyinstall) {
+    # boxstarter might be the one to install chocolatey itself, in this case there's no module present
+    # -> this is not a problem as consecutive calls will re-load this file via the boxstarter extension
+    Import-Module $env:chocolateyinstall\helpers\chocolateyInstaller.psm1 -Global -DisableNameChecking
+}
 
 New-Alias Install-ChocolateyInstallPackage Install-ChocolateyInstallPackageOverride -Force
 New-Alias Write-Host Write-HostOverride -Force

--- a/Boxstarter.Chocolatey/Get-PackageRoot.ps1
+++ b/Boxstarter.Chocolatey/Get-PackageRoot.ps1
@@ -28,9 +28,7 @@ try {
     $sublimeDir = "$env:programfiles\Sublime Text 2"
     mkdir "$sublimeDir\data"
     copy-item (Join-Path Get-PackageRoot($MyInvocation) 'sublime\*') "$sublimeDir\data" -Force -Recurse
-    Write-ChocolateySuccess 'MyPackage'
 } catch {
-  Write-ChocolateyFailure 'MyPackage' $($_.Exception.Message)
   throw
 }
 

--- a/Boxstarter.Chocolatey/New-BoxstarterPackage.ps1
+++ b/Boxstarter.Chocolatey/New-BoxstarterPackage.ps1
@@ -97,9 +97,9 @@ Get-PackageRoot
     $installScript=@"
 try {
 
-    Write-ChocolateySuccess '$name'
+  Write-Host "Hello, $name"
 } catch {
-  Write-ChocolateyFailure '$name' `$(`$_.Exception.Message)
+  # throw an exception when something fails
   throw
 }
 "@

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -54,338 +54,37 @@ function Invoke-Chocolatey($chocoArgs) {
     if (-Not (Test-Path "$env:ChocolateyInstall\lib")) {
         mkdir "$env:ChocolateyInstall\lib" | Out-Null
     }
-
-    $refs = @(
-        "$($env:ChocolateyInstall)/choco.exe"
-    )
-            
-    # FIXME wir müssen einen "hook" hinbekommen, sodass
-    # => boxstarter module/cmdlets/VARIABLEN im scope der choco.exe bekannt sind
-    # => weitere "choco" calls in einem Choco Pkg nicht an Chocolatey, sondern an die entsprechenden Boxstarter funktionen gehen
-    #    (sollte durch obigen Punkt automagisch gelöst sein)
-
-    # möglicher Workaround: "ur-version von MattWrock, aber choco.exe anstelle von dll laden?"
-    $refs | % {
-        Write-BoxstarterMessage "loading choco bytes" -Verbose
-        [System.Reflection.Assembly]::Load([io.file]::ReadAllBytes($_))
-    }
-    <#
-    Enter-BoxstarterLogable {
-
-        if (-Not $Boxstarter.LetsGetChocolatey) {
-            Write-BoxstarterMessage "calling 'boxstarter choco' now - setting up environment with '$chocoArgs'" -Verbose
-
-            $setupEnvScript = [scriptblock]::Create((Get-BoxstarterSetup))
-            $Boxstarter.LetsGetChocolatey = $true
-
-            $wrapperScript = {
-                param($verbosity, $thisBoxstarter, $chocoArgs)
-                $Global:VerbosePreference = $verbosity
-                $global:Boxstarter = $thisBoxstarter
-
-                Write-BoxstarterMessage "calling LetsGetchocolatey => 'choco $chocoArgs'" -Verbose
-                & choco $chocoArgs
-            }
-
-            $Boxstarter.Keys | % {
-                Write-Host "(ii) $_ -> $($Boxstarter[$_])"    
-            }
-            Write-Host "(ii) chocoArgs: $chocoArgs"
-
-            $jobArgs = @{
-                InitializationScript = $setupEnvScript
-                ScriptBlock          = $wrapperScript
-                ArgumentList         = @($Global:VerbosePreference, $Boxstarter, $chocoArgs)
-                Verbose              = $VerbosePreference
-            }
-            
-            $wrapperJob = Start-Job @jobArgs
-            Receive-Job -Job $wrapperJob -Wait -AutoRemoveJob
-
-        }
-        else {
-            Write-BoxstarterMessage "calling actual choco.exe now with '$chocoArgs'" -Verbose
-            $cd = [System.IO.Directory]::GetCurrentDirectory()
-            try {
-                Write-BoxstarterMessage "setting current directory location to $((Get-Location).Path)" -Verbose
-                [System.IO.Directory]::SetCurrentDirectory("$(Convert-Path (Get-Location).Path)")
-                
-                Write-BoxstarterMessage "BoxstarterWrapper::Run($chocoArgs)..." -Verbose
-                $pargs = @{
-                    FilePath          = Join-Path $env:ChocolateyInstall 'choco.exe'
-                    ArgumentList      = $chocoArgs.Split(" ")
-                    NoNewWindow       = $true
-                    PassThru          = $true
-                    UseNewEnvironment = $false
-                    Wait              = $true
-                }
-                
-                $p = Start-Process @pargs -Verbose
-                Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
-                [System.Environment]::ExitCode = $p.ExitCode
-
-            }
-            finally {
-                Write-BoxstarterMessage "restoring current directory location to $cd" -Verbose
-                [System.IO.Directory]::SetCurrentDirectory($cd)
-            }
-            
-        }       
-    }
-    #>
-
-    $cpar = New-Object System.CodeDom.Compiler.CompilerParameters
-    $cpar.ReferencedAssemblies.Add([System.Reflection.Assembly]::Load('System.Management.Automation').location) | Out-Null
-    $refs | % { $cpar.ReferencedAssemblies.Add($_) | Out-Null }
-    Write-BoxstarterMessage "Adding boxstarter choco wrapper types..." -Verbose
-    Add-Type @"
-namespace Boxstarter
-{
-    using chocolatey;
-    using chocolatey.infrastructure.app.services;
-    using chocolatey.infrastructure.filesystem;
-    using chocolatey.infrastructure.logging;
-    using System;
-    using System.IO;
-    using System.Management.Automation.Host;
-
-    public class ChocolateyWrapper
-    {
-        private static GetChocolatey _choco;
-
-        public ChocolateyWrapper(string boxstarterSetup, PSHostUserInterface ui, bool logDebug, bool logVerbose, string logPath, bool quiet) {
-            if (_choco == null) {
-                _choco = Lets.GetChocolatey();
-                var psService = new PowershellService(new DotNetFileSystem(), boxstarterSetup);
-                _choco.RegisterContainerComponent<IPowershellService>(() => psService);
-            }
-            _choco.SetCustomLogging(new PsLogger(ui, logDebug, logVerbose, logPath, quiet));
-        }
-
-        public void Run(string[] args) {
-            _choco.RunConsole(args);
-        }
-    }
-
-    public class PsLogger : ILog
-    {
-        private PSHostUserInterface _ui;
-        private string _path;
-        private bool _logDebug;
-        private bool _logVerbose;
-        private bool _quiet;
-
-        public PsLogger(PSHostUserInterface ui, bool logDebug, bool logVerbose, string path, bool quiet)
-        {
-            _ui = ui;
-            _logDebug = logDebug;
-            _logVerbose = logVerbose;
-            _path = path;
-            _quiet = quiet;
-        }
-
-        public void InitializeFor(string loggerName)
-        {
-        }
-
-        public void Debug(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => { if(_logDebug) _ui.WriteDebugLine(x); },
-                formatting
-            );
-        }
-
-        public void Debug(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => { if(_logDebug) _ui.WriteDebugLine(x); }
-            );
-        }
-
-        public void Info(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => {
-                        if(x.Trim().StartsWith("Boxstarter: ") || x.Replace("+","").Trim().StartsWith("Boxstarter ")){
-                            _ui.RawUI.ForegroundColor = ConsoleColor.Green;
-                        }
-                        else {
-                            _ui.RawUI.ForegroundColor = ConsoleColor.White;
-                        }
-                        if(x.Trim().StartsWith("VERBOSE: ")) {
-                            if(_logVerbose) _ui.WriteVerboseLine(x);
-                        }
-                        else {
-                            _ui.WriteLine(x);
-                        }
-                    },
-                formatting
-            );
-        }
-
-        public void Info(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => {
-                        if(x.Trim().StartsWith("Boxstarter: ") || x.Replace("+","").Trim().StartsWith("Boxstarter ")){
-                            _ui.RawUI.ForegroundColor = ConsoleColor.Green;
-                        }
-                        else {
-                            _ui.RawUI.ForegroundColor = ConsoleColor.White;
-                        }
-                        if(x.Trim().StartsWith("VERBOSE: ")) {
-                            if(_logVerbose) _ui.WriteVerboseLine(x);
-                        }
-                        else {
-                            _ui.WriteLine(x);
-                        }
-                    }
-            );
-        }
-
-        public void Warn(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => {
-                        _ui.RawUI.ForegroundColor = ConsoleColor.Yellow;
-                        _ui.WriteLine(x);
-                    },
-                formatting
-            );
-        }
-
-        public void Warn(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => {
-                        _ui.RawUI.ForegroundColor = ConsoleColor.Yellow;
-                        _ui.WriteLine(x);
-                    }
-            );
-        }
-
-        public void Error(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x),
-                formatting
-            );
-        }
-
-        public void Error(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x)
-            );
-        }
-
-        public void Fatal(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x),
-                formatting
-            );
-        }
-
-        public void Fatal(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x)
-            );
-        }
-
-        private void WriteLog(string message, Action<String> logAction, params object[] formatting)
-        {
-            WriteFormattedLog(() => String.Format(message, formatting), logAction);
-        }
-
-        private void WriteLog(Func<string> message, Action<String> logAction)
-        {
-            WriteFormattedLog(() => message.Invoke(), logAction);
-        }
-
-        private void WriteFormattedLog(Func<string> formatMessage, Action<String> logAction)
-        {
-            if(_quiet) return;
-            var origColor = _ui.RawUI.ForegroundColor;
-            try {
-                var msg = formatMessage.Invoke();
-                logAction.Invoke(msg);
-                WriteRaw(msg);
-            }
-            catch(Exception e) {
-                WriteRaw(e.ToString());
-            }
-            finally{
-                _ui.RawUI.ForegroundColor = origColor;
-            }
-        }
-
-        private void WriteRaw(string message)
-        {
-            if(String.IsNullOrEmpty(_path))
-                return;
-            try {
-                using (FileStream fs = new FileStream(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-                {
-                    using (StreamWriter sw = new StreamWriter(fs, System.Text.Encoding.UTF8))
-                    {
-                        sw.WriteLine(message);
-                    }
-                }
-            }
-            catch(Exception e)
-            {
-                _ui.WriteErrorLine(e.ToString());
-            }
-        }
-    }
-}
-"@ -CompilerParameters $cpar
-    Write-BoxstarterMessage "Types added..." -Verbose
-
-
-    if (!$global:choco) {
-        Write-BoxstarterMessage "instantiating choco wrapper..." -Verbose
-        $global:choco = New-Object -TypeName boxstarter.ChocolateyWrapper -ArgumentList `
-        (Get-BoxstarterSetup), `
-            $host.UI, `
-        ($global:DebugPreference -eq "Continue"), `
-        ($global:VerbosePreference -eq "Continue"), `
-            $boxstarter.log, `
-            $boxstarter.SuppressLogging
-    }
+    
+    Setup-BoxstarterExtension
 
     Enter-BoxstarterLogable {
-        Write-BoxstarterMessage "calling choco now with $chocoArgs" -Verbose
+
+        Write-BoxstarterMessage "calling actual choco.exe now with '$chocoArgs'" -Verbose
         $cd = [System.IO.Directory]::GetCurrentDirectory()
         try {
-            # Chocolatey.dll uses GetCurrentDirectory which is not quite right
-            # when calling via PowerShell. so we set it here
             Write-BoxstarterMessage "setting current directory location to $((Get-Location).Path)" -Verbose
             [System.IO.Directory]::SetCurrentDirectory("$(Convert-Path (Get-Location).Path)")
-            $choco.Run($chocoArgs)
+            
+            Write-BoxstarterMessage "BoxstarterWrapper::Run($chocoArgs)..." -Verbose
+            $pargs = @{
+                FilePath          = Join-Path $env:ChocolateyInstall 'choco.exe'
+                ArgumentList      = $chocoArgs.Split(" ")
+                NoNewWindow       = $true
+                PassThru          = $true
+                UseNewEnvironment = $false
+                Wait              = $true
+            }
+            
+            $p = Start-Process @pargs -Verbose
+            Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
+            [System.Environment]::ExitCode = $p.ExitCode
+
         }
         finally {
             Write-BoxstarterMessage "restoring current directory location to $cd" -Verbose
             [System.IO.Directory]::SetCurrentDirectory($cd)
         }
+            
     }
 
-
-}
-
-function Get-BoxstarterSetup {
-    "Import-Module '$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.Chocolatey.psd1' -DisableNameChecking -ArgumentList `$true"
 }

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -55,7 +55,7 @@ function Invoke-Chocolatey($chocoArgs) {
         mkdir "$env:ChocolateyInstall\lib" | Out-Null
     }
     
-    Setup-BoxstarterExtension
+    Install-BoxstarterExtension
 
     Enter-BoxstarterLogable {
 

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -78,12 +78,15 @@ function Invoke-Chocolatey($chocoArgs) {
                 NoNewWindow       = $true
                 PassThru          = $true
                 UseNewEnvironment = $false
-                Wait              = $true
+                Wait              = $false
                 WorkingDirectory  = $targetWdir
                 Verbose           = $VerbosePreference
             }
             
             $p = Start-Process @pargs
+
+            Wait-Process -Id $p.Id
+            
             Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
             [System.Environment]::ExitCode = $p.ExitCode
 

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -1,270 +1,80 @@
-function Invoke-Chocolatey($chocoArgs) {
-    Write-BoxstarterMessage "Current runtime is $($PSVersionTable.CLRVersion)" -Verbose
-    $refs = @(
-        "$($Boxstarter.BaseDir)/boxstarter.chocolatey/chocolatey/log4net.dll",
-        "$($Boxstarter.BaseDir)/boxstarter.chocolatey/chocolatey/chocolatey.dll"
-    )
-    $refs | % {
-        Write-BoxstarterMessage "Adding types from $_" -Verbose
-        if($env:TestingBoxstarter) {
-            Write-BoxstarterMessage "loading choco bytes" -Verbose
-            [System.Reflection.Assembly]::Load([io.file]::ReadAllBytes($_))
-        }
-        else {
-            Write-BoxstarterMessage "loading choco from path" -Verbose
-            Add-Type -Path $_
-        }
-    }
-    $cpar = New-Object System.CodeDom.Compiler.CompilerParameters
-    $cpar.ReferencedAssemblies.Add([System.Reflection.Assembly]::Load('System.Management.Automation').location) | Out-Null
-    $refs | % { $cpar.ReferencedAssemblies.Add($_) | Out-Null }
-    Write-BoxstarterMessage "Adding boxstarter choco wrapper types..." -Verbose
-    Add-Type @"
-namespace Boxstarter
-{
-    using chocolatey;
-    using chocolatey.infrastructure.app.services;
-    using chocolatey.infrastructure.filesystem;
-    using chocolatey.infrastructure.logging;
-    using System;
-    using System.IO;
-    using System.Management.Automation.Host;
 
-    public class ChocolateyWrapper
-    {
-        private static GetChocolatey _choco;
+function Expand-ZipFile($ZipFilePath, $DestinationFolder) {
+    if ($PSVersionTable.PSVersion.Major -ge 4) {
+        try {
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($ZipFilePath)
 
-        public ChocolateyWrapper(string boxstarterSetup, PSHostUserInterface ui, bool logDebug, bool logVerbose, string logPath, bool quiet) {
-            if (_choco == null) {
-                _choco = Lets.GetChocolatey();
-                var psService = new PowershellService(new DotNetFileSystem(), boxstarterSetup);
-                _choco.RegisterContainerComponent<IPowershellService>(() => psService);
-            }
-            _choco.SetCustomLogging(new PsLogger(ui, logDebug, logVerbose, logPath, quiet));
-        }
+            foreach ($entry in $archive.Entries) {
+                $entryTargetFilePath = [System.IO.Path]::Combine($DestinationFolder, $entry.FullName)
+                $entryDir = [System.IO.Path]::GetDirectoryName($entryTargetFilePath)
 
-        public void Run(string[] args) {
-            _choco.RunConsole(args);
-        }
-    }
+                if (!(Test-Path $entryDir)) {
+                    New-Item -ItemType Directory -Path $entryDir -Force | Out-Null
+                }
 
-    public class PsLogger : ILog
-    {
-        private PSHostUserInterface _ui;
-        private string _path;
-        private bool _logDebug;
-        private bool _logVerbose;
-        private bool _quiet;
-
-        public PsLogger(PSHostUserInterface ui, bool logDebug, bool logVerbose, string path, bool quiet)
-        {
-            _ui = ui;
-            _logDebug = logDebug;
-            _logVerbose = logVerbose;
-            _path = path;
-            _quiet = quiet;
-        }
-
-        public void InitializeFor(string loggerName)
-        {
-        }
-
-        public void Debug(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => { if(_logDebug) _ui.WriteDebugLine(x); },
-                formatting
-            );
-        }
-
-        public void Debug(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => { if(_logDebug) _ui.WriteDebugLine(x); }
-            );
-        }
-
-        public void Info(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => {
-                        if(x.Trim().StartsWith("Boxstarter: ") || x.Replace("+","").Trim().StartsWith("Boxstarter ")){
-                            _ui.RawUI.ForegroundColor = ConsoleColor.Green;
-                        }
-                        else {
-                            _ui.RawUI.ForegroundColor = ConsoleColor.White;
-                        }
-                        if(x.Trim().StartsWith("VERBOSE: ")) {
-                            if(_logVerbose) _ui.WriteVerboseLine(x);
-                        }
-                        else {
-                            _ui.WriteLine(x);
-                        }
-                    },
-                formatting
-            );
-        }
-
-        public void Info(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => {
-                        if(x.Trim().StartsWith("Boxstarter: ") || x.Replace("+","").Trim().StartsWith("Boxstarter ")){
-                            _ui.RawUI.ForegroundColor = ConsoleColor.Green;
-                        }
-                        else {
-                            _ui.RawUI.ForegroundColor = ConsoleColor.White;
-                        }
-                        if(x.Trim().StartsWith("VERBOSE: ")) {
-                            if(_logVerbose) _ui.WriteVerboseLine(x);
-                        }
-                        else {
-                            _ui.WriteLine(x);
-                        }
-                    }
-            );
-        }
-
-        public void Warn(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => {
-                        _ui.RawUI.ForegroundColor = ConsoleColor.Yellow;
-                        _ui.WriteLine(x);
-                    },
-                formatting
-            );
-        }
-
-        public void Warn(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => {
-                        _ui.RawUI.ForegroundColor = ConsoleColor.Yellow;
-                        _ui.WriteLine(x);
-                    }
-            );
-        }
-
-        public void Error(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x),
-                formatting
-            );
-        }
-
-        public void Error(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x)
-            );
-        }
-
-        public void Fatal(string message, params object[] formatting)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x),
-                formatting
-            );
-        }
-
-        public void Fatal(Func<string> message)
-        {
-            WriteLog(
-                message,
-                x => _ui.WriteErrorLine(x)
-            );
-        }
-
-        private void WriteLog(string message, Action<String> logAction, params object[] formatting)
-        {
-            WriteFormattedLog(() => String.Format(message, formatting), logAction);
-        }
-
-        private void WriteLog(Func<string> message, Action<String> logAction)
-        {
-            WriteFormattedLog(() => message.Invoke(), logAction);
-        }
-
-        private void WriteFormattedLog(Func<string> formatMessage, Action<String> logAction)
-        {
-            if(_quiet) return;
-            var origColor = _ui.RawUI.ForegroundColor;
-            try {
-                var msg = formatMessage.Invoke();
-                logAction.Invoke(msg);
-                WriteRaw(msg);
-            }
-            catch(Exception e) {
-                WriteRaw(e.ToString());
-            }
-            finally{
-                _ui.RawUI.ForegroundColor = origColor;
-            }
-        }
-
-        private void WriteRaw(string message)
-        {
-            if(String.IsNullOrEmpty(_path))
-                return;
-            try {
-                using (FileStream fs = new FileStream(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-                {
-                    using (StreamWriter sw = new StreamWriter(fs, System.Text.Encoding.UTF8))
-                    {
-                        sw.WriteLine(message);
-                    }
+                if (!$entryTargetFilePath.EndsWith("/")) {
+                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $entryTargetFilePath, $true);
                 }
             }
-            catch(Exception e)
-            {
-                _ui.WriteErrorLine(e.ToString());
-            }
+        }
+        catch {
+            throw $_
         }
     }
+    else {
+        #original method
+        $shellApplication = new-object -com shell.application
+        $zipPackage = $shellApplication.NameSpace($ZipFilePath)
+        $DestinationF = $shellApplication.NameSpace($DestinationFolder)
+        $DestinationF.CopyHere($zipPackage.Items(), 0x10)
+    }
 }
-"@ -CompilerParameters $cpar
-    Write-BoxstarterMessage "Types added..." -Verbose
 
-    if(!$env:ChocolateyInstall) {
+
+function Invoke-Chocolatey($chocoArgs) {
+    Write-BoxstarterMessage "Current runtime is $($PSVersionTable.CLRVersion)" -Verbose
+
+    if (-Not $env:ChocolateyInstall) {
         [System.Environment]::SetEnvironmentVariable('ChocolateyInstall', "$env:programdata\chocolatey", 'Machine')
         $env:ChocolateyInstall = "$env:programdata\chocolatey"
     }
 
-    if(!(Test-Path "$env:ChocolateyInstall\lib")) {
-        mkdir "$env:ChocolateyInstall\lib" | Out-Null
+    if (-Not (Test-Path $env:ChocolateyInstall)) {
+        Write-BoxstarterMessage "SNAP! Chocolatey seems to be missing! - installing NOW!"
+        $boxstarterZip = Get-Item "$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.zip"
+        $tmpBoxstarterUnzipPath = "$($env:temp)\boxstarter_temp"
+        Expand-ZipFile -ZipFilePath $boxstarterZip.FullName -DestinationFolder $tmpBoxstarterUnzipPath
+        $chocoNupkg = Get-Item "$tmpBoxstarterUnzipPath\Boxstarter.Chocolatey\chocolatey\*.nupkg" | Select-Object -First 1
+        Expand-ZipFile -ZipFilePath $chocoNupkg.FullName -DestinationFolder $env:temp\boxstarter_chocolatey
+        Import-Module $env:temp\boxstarter_chocolatey\tools\chocolateysetup.psm1 -DisableNameChecking
+        Initialize-Chocolatey
     }
 
-    if(!$global:choco) {
-        Write-BoxstarterMessage "instantiating choco wrapper..." -Verbose
-        $global:choco = New-Object -TypeName boxstarter.ChocolateyWrapper -ArgumentList `
-          (Get-BoxstarterSetup),`
-          $host.UI,`
-          ($global:DebugPreference -eq "Continue"),`
-          ($global:VerbosePreference -eq "Continue"),`
-          $boxstarter.log,`
-          $boxstarter.SuppressLogging
+    if (-Not (Test-Path "$env:ChocolateyInstall\lib")) {
+        mkdir "$env:ChocolateyInstall\lib" | Out-Null
     }
 
     Enter-BoxstarterLogable {
         Write-BoxstarterMessage "calling choco now with $chocoArgs" -Verbose
         $cd = [System.IO.Directory]::GetCurrentDirectory()
         try {
-            # Chocolatey.dll uses GetCurrentDirectory which is not quite right
-            # when calling via PowerShell. so we set it here
             Write-BoxstarterMessage "setting current directory location to $((Get-Location).Path)" -Verbose
             [System.IO.Directory]::SetCurrentDirectory("$(Convert-Path (Get-Location).Path)")
-            $choco.Run($chocoArgs)
+            
+            Write-BoxstarterMessage "BoxstarterWrapper::Run($chocoArgs)..." -Verbose
+            $pargs = @{
+                FilePath          = Join-Path $env:ChocolateyInstall 'choco.exe'
+                ArgumentList      = $chocoArgs
+                NoNewWindow       = $true
+                PassThru          = $true
+                UseNewEnvironment = $false
+                Wait              = $true
+            }
+            $p = Start-Process @pargs -Verbose
+            Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
+            [System.Environment]::ExitCode = $p.ExitCode
+
         }
         finally {
             Write-BoxstarterMessage "restoring current directory location to $cd" -Verbose
@@ -274,5 +84,5 @@ namespace Boxstarter
 }
 
 function Get-BoxstarterSetup {
-"Import-Module '$($boxstarter.BaseDir)\Boxstarter.chocolatey\Boxstarter.chocolatey.psd1' -DisableNameChecking -ArgumentList `$true"
+    "Import-Module '$($boxstarter.BaseDir)\Boxstarter.Chocolatey\Boxstarter.Chocolatey.psd1' -DisableNameChecking -ArgumentList `$true"
 }

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -55,32 +55,335 @@ function Invoke-Chocolatey($chocoArgs) {
         mkdir "$env:ChocolateyInstall\lib" | Out-Null
     }
 
+    $refs = @(
+        "$($env:ChocolateyInstall)/choco.exe"
+    )
+            
+    # FIXME wir müssen einen "hook" hinbekommen, sodass
+    # => boxstarter module/cmdlets/VARIABLEN im scope der choco.exe bekannt sind
+    # => weitere "choco" calls in einem Choco Pkg nicht an Chocolatey, sondern an die entsprechenden Boxstarter funktionen gehen
+    #    (sollte durch obigen Punkt automagisch gelöst sein)
+
+    # möglicher Workaround: "ur-version von MattWrock, aber choco.exe anstelle von dll laden?"
+    $refs | % {
+        Write-BoxstarterMessage "loading choco bytes" -Verbose
+        [System.Reflection.Assembly]::Load([io.file]::ReadAllBytes($_))
+    }
+    <#
+    Enter-BoxstarterLogable {
+
+        if (-Not $Boxstarter.LetsGetChocolatey) {
+            Write-BoxstarterMessage "calling 'boxstarter choco' now - setting up environment with '$chocoArgs'" -Verbose
+
+            $setupEnvScript = [scriptblock]::Create((Get-BoxstarterSetup))
+            $Boxstarter.LetsGetChocolatey = $true
+
+            $wrapperScript = {
+                param($verbosity, $thisBoxstarter, $chocoArgs)
+                $Global:VerbosePreference = $verbosity
+                $global:Boxstarter = $thisBoxstarter
+
+                Write-BoxstarterMessage "calling LetsGetchocolatey => 'choco $chocoArgs'" -Verbose
+                & choco $chocoArgs
+            }
+
+            $Boxstarter.Keys | % {
+                Write-Host "(ii) $_ -> $($Boxstarter[$_])"    
+            }
+            Write-Host "(ii) chocoArgs: $chocoArgs"
+
+            $jobArgs = @{
+                InitializationScript = $setupEnvScript
+                ScriptBlock          = $wrapperScript
+                ArgumentList         = @($Global:VerbosePreference, $Boxstarter, $chocoArgs)
+                Verbose              = $VerbosePreference
+            }
+            
+            $wrapperJob = Start-Job @jobArgs
+            Receive-Job -Job $wrapperJob -Wait -AutoRemoveJob
+
+        }
+        else {
+            Write-BoxstarterMessage "calling actual choco.exe now with '$chocoArgs'" -Verbose
+            $cd = [System.IO.Directory]::GetCurrentDirectory()
+            try {
+                Write-BoxstarterMessage "setting current directory location to $((Get-Location).Path)" -Verbose
+                [System.IO.Directory]::SetCurrentDirectory("$(Convert-Path (Get-Location).Path)")
+                
+                Write-BoxstarterMessage "BoxstarterWrapper::Run($chocoArgs)..." -Verbose
+                $pargs = @{
+                    FilePath          = Join-Path $env:ChocolateyInstall 'choco.exe'
+                    ArgumentList      = $chocoArgs.Split(" ")
+                    NoNewWindow       = $true
+                    PassThru          = $true
+                    UseNewEnvironment = $false
+                    Wait              = $true
+                }
+                
+                $p = Start-Process @pargs -Verbose
+                Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
+                [System.Environment]::ExitCode = $p.ExitCode
+
+            }
+            finally {
+                Write-BoxstarterMessage "restoring current directory location to $cd" -Verbose
+                [System.IO.Directory]::SetCurrentDirectory($cd)
+            }
+            
+        }       
+    }
+    #>
+
+    $cpar = New-Object System.CodeDom.Compiler.CompilerParameters
+    $cpar.ReferencedAssemblies.Add([System.Reflection.Assembly]::Load('System.Management.Automation').location) | Out-Null
+    $refs | % { $cpar.ReferencedAssemblies.Add($_) | Out-Null }
+    Write-BoxstarterMessage "Adding boxstarter choco wrapper types..." -Verbose
+    Add-Type @"
+namespace Boxstarter
+{
+    using chocolatey;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.filesystem;
+    using chocolatey.infrastructure.logging;
+    using System;
+    using System.IO;
+    using System.Management.Automation.Host;
+
+    public class ChocolateyWrapper
+    {
+        private static GetChocolatey _choco;
+
+        public ChocolateyWrapper(string boxstarterSetup, PSHostUserInterface ui, bool logDebug, bool logVerbose, string logPath, bool quiet) {
+            if (_choco == null) {
+                _choco = Lets.GetChocolatey();
+                var psService = new PowershellService(new DotNetFileSystem(), boxstarterSetup);
+                _choco.RegisterContainerComponent<IPowershellService>(() => psService);
+            }
+            _choco.SetCustomLogging(new PsLogger(ui, logDebug, logVerbose, logPath, quiet));
+        }
+
+        public void Run(string[] args) {
+            _choco.RunConsole(args);
+        }
+    }
+
+    public class PsLogger : ILog
+    {
+        private PSHostUserInterface _ui;
+        private string _path;
+        private bool _logDebug;
+        private bool _logVerbose;
+        private bool _quiet;
+
+        public PsLogger(PSHostUserInterface ui, bool logDebug, bool logVerbose, string path, bool quiet)
+        {
+            _ui = ui;
+            _logDebug = logDebug;
+            _logVerbose = logVerbose;
+            _path = path;
+            _quiet = quiet;
+        }
+
+        public void InitializeFor(string loggerName)
+        {
+        }
+
+        public void Debug(string message, params object[] formatting)
+        {
+            WriteLog(
+                message,
+                x => { if(_logDebug) _ui.WriteDebugLine(x); },
+                formatting
+            );
+        }
+
+        public void Debug(Func<string> message)
+        {
+            WriteLog(
+                message,
+                x => { if(_logDebug) _ui.WriteDebugLine(x); }
+            );
+        }
+
+        public void Info(string message, params object[] formatting)
+        {
+            WriteLog(
+                message,
+                x => {
+                        if(x.Trim().StartsWith("Boxstarter: ") || x.Replace("+","").Trim().StartsWith("Boxstarter ")){
+                            _ui.RawUI.ForegroundColor = ConsoleColor.Green;
+                        }
+                        else {
+                            _ui.RawUI.ForegroundColor = ConsoleColor.White;
+                        }
+                        if(x.Trim().StartsWith("VERBOSE: ")) {
+                            if(_logVerbose) _ui.WriteVerboseLine(x);
+                        }
+                        else {
+                            _ui.WriteLine(x);
+                        }
+                    },
+                formatting
+            );
+        }
+
+        public void Info(Func<string> message)
+        {
+            WriteLog(
+                message,
+                x => {
+                        if(x.Trim().StartsWith("Boxstarter: ") || x.Replace("+","").Trim().StartsWith("Boxstarter ")){
+                            _ui.RawUI.ForegroundColor = ConsoleColor.Green;
+                        }
+                        else {
+                            _ui.RawUI.ForegroundColor = ConsoleColor.White;
+                        }
+                        if(x.Trim().StartsWith("VERBOSE: ")) {
+                            if(_logVerbose) _ui.WriteVerboseLine(x);
+                        }
+                        else {
+                            _ui.WriteLine(x);
+                        }
+                    }
+            );
+        }
+
+        public void Warn(string message, params object[] formatting)
+        {
+            WriteLog(
+                message,
+                x => {
+                        _ui.RawUI.ForegroundColor = ConsoleColor.Yellow;
+                        _ui.WriteLine(x);
+                    },
+                formatting
+            );
+        }
+
+        public void Warn(Func<string> message)
+        {
+            WriteLog(
+                message,
+                x => {
+                        _ui.RawUI.ForegroundColor = ConsoleColor.Yellow;
+                        _ui.WriteLine(x);
+                    }
+            );
+        }
+
+        public void Error(string message, params object[] formatting)
+        {
+            WriteLog(
+                message,
+                x => _ui.WriteErrorLine(x),
+                formatting
+            );
+        }
+
+        public void Error(Func<string> message)
+        {
+            WriteLog(
+                message,
+                x => _ui.WriteErrorLine(x)
+            );
+        }
+
+        public void Fatal(string message, params object[] formatting)
+        {
+            WriteLog(
+                message,
+                x => _ui.WriteErrorLine(x),
+                formatting
+            );
+        }
+
+        public void Fatal(Func<string> message)
+        {
+            WriteLog(
+                message,
+                x => _ui.WriteErrorLine(x)
+            );
+        }
+
+        private void WriteLog(string message, Action<String> logAction, params object[] formatting)
+        {
+            WriteFormattedLog(() => String.Format(message, formatting), logAction);
+        }
+
+        private void WriteLog(Func<string> message, Action<String> logAction)
+        {
+            WriteFormattedLog(() => message.Invoke(), logAction);
+        }
+
+        private void WriteFormattedLog(Func<string> formatMessage, Action<String> logAction)
+        {
+            if(_quiet) return;
+            var origColor = _ui.RawUI.ForegroundColor;
+            try {
+                var msg = formatMessage.Invoke();
+                logAction.Invoke(msg);
+                WriteRaw(msg);
+            }
+            catch(Exception e) {
+                WriteRaw(e.ToString());
+            }
+            finally{
+                _ui.RawUI.ForegroundColor = origColor;
+            }
+        }
+
+        private void WriteRaw(string message)
+        {
+            if(String.IsNullOrEmpty(_path))
+                return;
+            try {
+                using (FileStream fs = new FileStream(_path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+                {
+                    using (StreamWriter sw = new StreamWriter(fs, System.Text.Encoding.UTF8))
+                    {
+                        sw.WriteLine(message);
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                _ui.WriteErrorLine(e.ToString());
+            }
+        }
+    }
+}
+"@ -CompilerParameters $cpar
+    Write-BoxstarterMessage "Types added..." -Verbose
+
+
+    if (!$global:choco) {
+        Write-BoxstarterMessage "instantiating choco wrapper..." -Verbose
+        $global:choco = New-Object -TypeName boxstarter.ChocolateyWrapper -ArgumentList `
+        (Get-BoxstarterSetup), `
+            $host.UI, `
+        ($global:DebugPreference -eq "Continue"), `
+        ($global:VerbosePreference -eq "Continue"), `
+            $boxstarter.log, `
+            $boxstarter.SuppressLogging
+    }
+
     Enter-BoxstarterLogable {
         Write-BoxstarterMessage "calling choco now with $chocoArgs" -Verbose
         $cd = [System.IO.Directory]::GetCurrentDirectory()
         try {
+            # Chocolatey.dll uses GetCurrentDirectory which is not quite right
+            # when calling via PowerShell. so we set it here
             Write-BoxstarterMessage "setting current directory location to $((Get-Location).Path)" -Verbose
             [System.IO.Directory]::SetCurrentDirectory("$(Convert-Path (Get-Location).Path)")
-            
-            Write-BoxstarterMessage "BoxstarterWrapper::Run($chocoArgs)..." -Verbose
-            $pargs = @{
-                FilePath          = Join-Path $env:ChocolateyInstall 'choco.exe'
-                ArgumentList      = $chocoArgs
-                NoNewWindow       = $true
-                PassThru          = $true
-                UseNewEnvironment = $false
-                Wait              = $true
-            }
-            $p = Start-Process @pargs -Verbose
-            Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
-            [System.Environment]::ExitCode = $p.ExitCode
-
+            $choco.Run($chocoArgs)
         }
         finally {
             Write-BoxstarterMessage "restoring current directory location to $cd" -Verbose
             [System.IO.Directory]::SetCurrentDirectory($cd)
         }
     }
+
+
 }
 
 function Get-BoxstarterSetup {

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -73,9 +73,10 @@ function Invoke-Chocolatey($chocoArgs) {
                 PassThru          = $true
                 UseNewEnvironment = $false
                 Wait              = $true
+                Verbose           = $VerbosePreference
             }
             
-            $p = Start-Process @pargs -Verbose
+            $p = Start-Process @pargs
             Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
             [System.Environment]::ExitCode = $p.ExitCode
 

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -59,20 +59,27 @@ function Invoke-Chocolatey($chocoArgs) {
 
     Enter-BoxstarterLogable {
 
-        Write-BoxstarterMessage "calling actual choco.exe now with '$chocoArgs'" -Verbose
         $cd = [System.IO.Directory]::GetCurrentDirectory()
         try {
-            Write-BoxstarterMessage "setting current directory location to $((Get-Location).Path)" -Verbose
-            [System.IO.Directory]::SetCurrentDirectory("$(Convert-Path (Get-Location).Path)")
+            $targetWdir = $((Get-Location).Path)
+            Write-BoxstarterMessage "setting current directory location to $targetWdir" -Verbose
+            [System.IO.Directory]::SetCurrentDirectory("$(Convert-Path $targetWdir)")
             
             Write-BoxstarterMessage "BoxstarterWrapper::Run($chocoArgs)..." -Verbose
+            <#
+            $chocoArgs | ForEach-Object {
+              Write-BoxStarterMessage " -> $_" -Verbose
+            }
+            #>
+
             $pargs = @{
                 FilePath          = Join-Path $env:ChocolateyInstall 'choco.exe'
-                ArgumentList      = $chocoArgs.Split(" ")
+                ArgumentList      = $chocoArgs
                 NoNewWindow       = $true
                 PassThru          = $true
                 UseNewEnvironment = $false
                 Wait              = $true
+                WorkingDirectory  = $targetWdir
                 Verbose           = $VerbosePreference
             }
             

--- a/BuildPackages/example/tools/chocolateyInstall.ps1
+++ b/BuildPackages/example/tools/chocolateyInstall.ps1
@@ -60,8 +60,6 @@ try {
     Install-ChocolateyVsixPackage autowrocktestable http://visualstudiogallery.msdn.microsoft.com/ea3a37c9-1c76-4628-803e-b10a109e7943/file/73131/1/AutoWrockTestable.vsix
     Install-ChocolateyVsixPackage vscommands http://visualstudiogallery.msdn.microsoft.com/a83505c6-77b3-44a6-b53b-73d77cba84c8/file/74740/18/SquaredInfinity.VSCommands.VS11.vsix
     Install-WindowsUpdate -AcceptEula
-    Write-ChocolateySuccess 'example'
 } catch {
-  Write-ChocolateyFailure 'example' $($_.Exception.Message)
   throw
 }

--- a/BuildScripts/build.ps1
+++ b/BuildScripts/build.ps1
@@ -3,7 +3,8 @@ param (
     [switch]$Help,
     [string]$VmName,
     [string]$package,
-    [string]$testName
+    [string]$testName,
+    [switch]$DoRelease
 )
 $here = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 if(-not $env:ChocolateyInstall -or -not (Test-Path "$env:ChocolateyInstall")){
@@ -26,10 +27,14 @@ if($Help){
   return
 }
 
+if ($DoRelease) {
+    $env:DO_BOXSTARTER_RELEASE = $true
+}
 $psakeDir = (Get-ChildItem $env:ChocolateyInstall\lib\Psake*)
 if($psakeDir.length -gt 0) {$psakeDir = $psakeDir[-1]}
 ."$psakeDir\tools\psake\psake.ps1" "$here/default.ps1" $Action -ScriptPath $psakeDir\tools\psake -parameters $PSBoundParameters
 
+$env:DO_BOXSTARTER_RELEASE = $false
 if($psake.build_success -eq $false) {
   exit 1;
 }

--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -259,8 +259,9 @@ Task Restore-NuGetPackages {
 
 task Install-ChocoPkg {
     MkDir $basedir\Boxstarter.Chocolatey\chocolatey -ErrorAction SilentlyContinue
-    $srcUrl = 'https://community.chocolatey.org/api/v2/package/chocolatey/0.11.2'
-    $targetFile = 'chocolatey.0.11.2.nupkg'
+    $chocoVersion = "0.11.3"
+    $srcUrl = "https://community.chocolatey.org/api/v2/package/chocolatey/$chocoVersion"
+    $targetFile = "chocolatey.$chocoVersion.nupkg"
     Push-Location $basedir\Boxstarter.Chocolatey\chocolatey
     try {
         if (-Not (Test-Path $targetFile)) {

--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -152,7 +152,7 @@ Task Pack-NuGet -depends Sign-PowerShellFiles -description 'Packs the modules an
     }
 
     PackDirectory "$baseDir\BuildPackages"
-    PackDirectory "$baseDir\BuildScripts\nuget" -AddReleaseNotes
+    PackDirectory "$baseDir\BuildScripts\nuget" -AddReleaseNotes -Version $chocoPkgVersion
     Move-Item "$baseDir\BuildScripts\nuget\*.nupkg" "$basedir\buildArtifacts"
 }
 
@@ -323,7 +323,7 @@ task Sign-PowerShellFiles -depends Copy-PowerShellFiles {
     }
 }
 
-function PackDirectory($path, [switch]$AddReleaseNotes){
+function PackDirectory($path, [switch]$AddReleaseNotes, $Version = $version){
     exec {
         $releaseNotes = Get-ReleaseNotes
         Get-ChildItem $path -Recurse -include *.nuspec |
@@ -335,7 +335,7 @@ function PackDirectory($path, [switch]$AddReleaseNotes){
                    $nuspec.package.metadata.ReplaceChild($newReleaseNotes, $oldReleaseNotes) | Out-Null
                    $nuspec.Save($_)
                  }
-                 .$nugetExe pack $_ -OutputDirectory $path -NoPackageAnalysis -version $chocoPkgVersion
+                 .$nugetExe pack $_ -OutputDirectory $path -NoPackageAnalysis -version $Version
               }
     }
 }

--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -8,6 +8,10 @@ properties {
         $versionTag = $list[$list.Count-1].ToString()
         $version = $versionTag + "."
         $version += (git log $($version + '..') --pretty=oneline | measure-object).Count
+        $chocoPkgVersion = $version
+        if (-not $env:DO_BOXSTARTER_RELEASE) {
+            $chocoPkgVersion += '-beta'
+        }
         $changeset = (git log -1 $($versionTag + '..') --pretty=format:%H)
         if($changeset -eq $null) {
             $changeset = (git log -1 --pretty=format:%H)
@@ -15,6 +19,7 @@ properties {
     }
     else {
         $version="1.0.0"
+        $chocoPkgVersion = $version
     }
     $nugetExe = "$env:ChocolateyInstall\bin\nuget.exe"
     $ftpHost="waws-prod-bay-001.ftp.azurewebsites.windows.net"
@@ -156,16 +161,16 @@ Task Package-DownloadZip -depends Clean-Artifacts {
       Remove-Item "$basedir\BuildArtifacts\Boxstarter.*.zip" -Force
     }
 
-    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$version.zip" "$basedir\LICENSE.txt" }
-    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$version.zip" "$basedir\NOTICE.txt" }
-    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$version.zip" "$basedir\buildscripts\bootstrapper.ps1" }
-    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$version.zip" "$basedir\buildscripts\Setup.bat" }
+    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$chocoPkgVersion.zip" "$basedir\LICENSE.txt" }
+    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$chocoPkgVersion.zip" "$basedir\NOTICE.txt" }
+    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$chocoPkgVersion.zip" "$basedir\buildscripts\bootstrapper.ps1" }
+    exec { ."$env:chocolateyInstall\bin\7za.exe" a -tzip "$basedir\BuildArtifacts\Boxstarter.$chocoPkgVersion.zip" "$basedir\buildscripts\Setup.bat" }
 }
 
 Task Deploy-DownloadZip -depends Package-DownloadZip {
     Remove-Item "$basedir\web\downloads" -Recurse -Force -ErrorAction SilentlyContinue
     mkdir "$basedir\web\downloads"
-    Copy-Item "$basedir\BuildArtifacts\Boxstarter.$version.zip" "$basedir\web\downloads"
+    Copy-Item "$basedir\BuildArtifacts\Boxstarter.$chocoPkgVersion.zip" "$basedir\web\downloads"
 }
 
 Task Deploy-Bootstrapper {
@@ -189,25 +194,25 @@ Task Push-Github {
 
     $releaseNotes = Get-ReleaseNotes
     $postParams = ConvertTo-Json @{
-        tag_name="v$version"
+        tag_name="v$chocoPkgVersion"
         target_commitish=$changeset
-        name="v$version"
+        name="v$chocoPkgVersion"
         body=$releaseNotes.DocumentElement.'#text'
     } -Compress
 
     $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/chocolatey/boxstarter/releases/latest" -Method GET -Headers $headers
-    if($latest.tag_name -ne "v$version"){
+    if($latest.tag_name -ne "v$chocoPkgVersion"){
         Write-Host "Creating release"
         $response = Invoke-RestMethod -Uri "https://api.github.com/repos/chocolatey/boxstarter/releases" -Method POST -Body $postParams -Headers $headers
-        $uploadUrl = $response.upload_url.replace("{?name,label}","?name=boxstarter.$version.zip")
+        $uploadUrl = $response.upload_url.replace("{?name,label}","?name=boxstarter.$chocoPkgVersion.zip")
     }
     else {
-        $uploadUrl = $latest.upload_url.replace("{?name,label}","?name=boxstarter.$version.zip")
+        $uploadUrl = $latest.upload_url.replace("{?name,label}","?name=boxstarter.$chocoPkgVersion.zip")
     }
 
-    Write-Host "Uploading $basedir\BuildArtifacts\Boxstarter.$version.zip to $uploadUrl"
+    Write-Host "Uploading $basedir\BuildArtifacts\Boxstarter.$chocoPkgVersion.zip to $uploadUrl"
     try {
-        Invoke-RestMethod -Uri $uploadUrl -Method POST -ContentType "application/zip" -InFile "$basedir\BuildArtifacts\Boxstarter.$version.zip" -Headers $headers
+        Invoke-RestMethod -Uri $uploadUrl -Method POST -ContentType "application/zip" -InFile "$basedir\BuildArtifacts\Boxstarter.$chocoPkgVersion.zip" -Headers $headers
     }
     catch{
         write-host $_ | Format-List * -force
@@ -265,6 +270,7 @@ task Install-ChocoPkg {
     Push-Location $basedir\Boxstarter.Chocolatey\chocolatey
     try {
         if (-Not (Test-Path $targetFile)) {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
             Invoke-WebRequest -Uri $srcUrl -OutFile $targetFile
         }
     }
@@ -329,7 +335,7 @@ function PackDirectory($path, [switch]$AddReleaseNotes){
                    $nuspec.package.metadata.ReplaceChild($newReleaseNotes, $oldReleaseNotes) | Out-Null
                    $nuspec.Save($_)
                  }
-                 .$nugetExe pack $_ -OutputDirectory $path -NoPackageAnalysis -version $version
+                 .$nugetExe pack $_ -OutputDirectory $path -NoPackageAnalysis -version $chocoPkgVersion
               }
     }
 }

--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -264,7 +264,7 @@ Task Restore-NuGetPackages {
 
 task Install-ChocoPkg {
     MkDir $basedir\Boxstarter.Chocolatey\chocolatey -ErrorAction SilentlyContinue
-    $chocoVersion = "0.11.3"
+    $chocoVersion = "1.1.0"
     $srcUrl = "https://community.chocolatey.org/api/v2/package/chocolatey/$chocoVersion"
     $targetFile = "chocolatey.$chocoVersion.nupkg"
     Push-Location $basedir\Boxstarter.Chocolatey\chocolatey

--- a/Web/CreatingPackages.cshtml
+++ b/Web/CreatingPackages.cshtml
@@ -42,9 +42,8 @@ New-BoxstarterPackage -Name MyPackage -Description "I hope you enjoy MyPackage"
 <p>And a tools/ChocolateyInstall.ps1 with this code:</p>
 <pre>
 try {
-    Write-ChocolateySuccess 'MyPackage'
+  Write-Host 'MyPackage'
 } catch {
-  Write-ChocolateyFailure 'MyPackage' $($_.Exception.Message)
   throw
 }
 </pre>

--- a/Web/Learn/RemotePackageWithArtifacts.cshtml
+++ b/Web/Learn/RemotePackageWithArtifacts.cshtml
@@ -66,9 +66,8 @@ try {
     #Client SKUs need to enable firewall
     netsh advfirewall firewall add rule name="Open Port 80" dir=in action=allow protocol=TCP localport=80
 
-    Write-ChocolateySuccess 'NugetServer'
+    Write-Host 'NugetServer'
 } catch {
-  Write-ChocolateyFailure 'NugetServer' $($_.Exception.ToString())
   throw
 }
 </pre>

--- a/deployment.md
+++ b/deployment.md
@@ -10,7 +10,7 @@
 
 ## Prerequisites
 
-* Run `.\build.bat Install-ChocoLib` - this will place the required version of the Chocolatey Lib into the Boxstarter.Chocolatey folder
+* Run `.\build.bat Install-ChocoPkg` - this will place the 'included' version of the Chocolatey nupkg into the Boxstarter.Chocolatey folder
 * You will need a code signing certificate installed in your personal certificate store
 * The thumbprint of that certificate needs to be specified in the `ManifestCertificateThumbprint` property inside the `Boxstarter.ClickOnce` `.csproj` file.
 * You should set `$env:BOXSTARTER_GITHUB_USERNAME` to your GitHub username

--- a/tests/Chocolatey/Chocolatey.tests.ps1
+++ b/tests/Chocolatey/Chocolatey.tests.ps1
@@ -495,6 +495,32 @@ Describe "Call-Chocolatey" {
 
 }
 
+Describe "Boxstarter Chocolatey edge cases" {
+
+    context "calls chocolatey with arbitrary package" {
+        $script:passedArgs = ""
+        Mock Call-Chocolatey {$global:LASTEXITCODE=0}
+
+        choco Install foobar -force:$false
+
+        it "passes expected params" {
+            Assert-MockCalled Call-Chocolatey -times 1
+        }
+    }
+
+    context "does NOT call chocolatey for installing chocolatey" {
+        $script:passedArgs = ""
+        Mock Call-Chocolatey {$global:LASTEXITCODE=0}
+
+        choco Install chocolatey -force:$false
+
+        it "passes expected params" {
+            Assert-MockCalled Call-Chocolatey -times 0
+        }
+    }
+
+}
+
 Describe "Get-PackageNamesFromInvocationLine" {
     It "extracts single package name from default invocation style" {
         $pkgNames = Get-PackageNamesFromInvocationLine @("-y", "-f", "packagename", "-s", "myfeed")


### PR DESCRIPTION
## Description
+ rip out chocolatey.dll (use choco.exe from $env:ChocolateyInstall)
+ install chocolatey from nupkg if not present (local + remote)

## Related Issue

Fixes #247
Fixes #369
Fixes #394
Fixes #423
Fixes #442
Fixes #455

## Motivation and Context
To be able to use the neweset functionality within Chocolatey would require unbundling Chocolatey within Boxstarter and using the latest* version from Chocolatey.org.

With this PR, Boxstarter will always try to use the Chocolatey version from $env:ChocolateyInstall or install Chocolatey from a chocolatey.nupkg that comes with Boxstarter and should easily be updated whenever a new version of Chocolatey is released. (I intentionally do not use 'latest' here, because there might be unforseen issues with a newer version - hence it's safer to stick with a 'known-to-be-good' version until verified/tested. / as of today, Boxstarter would 'ship' with Chocolatey 0.11.3)

Currently Boxstarter uses it's own version for remote installs but the remote installs could install, or use the current version of the Chocolatey package on the local machine to install remotely.

## How Has This Been Tested?
Mainly on my dev-pc, use `psake Package` in the "buildscripts" directory to build artifacts that can be installed via chocolatey or simply use `boxstartershell.ps1` (note: you still need to `psake Package` before!) and use `Install-BoxstarterPackage` on a remote host.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
