### PR TITLE
(#209) Disable Browser First Run Wizards

### DIFF
--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psd1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psd1
@@ -47,7 +47,8 @@ CmdletsToExport = @(
   'Set-WindowsExplorerOptions',
   'Set-BoxstarterTaskbarOptions',
   'Disable-BingSearch', 
-  'Set-BoxstarterPageFile'
+  'Set-BoxstarterPageFile', 
+  'Disable-BoxstarterBrowserFirstRun'
 )
 
 # Variables to export from this module
@@ -69,4 +70,3 @@ PrivateData = '8459d49a8d5a049d8936519ccf045706c7b3eb23'
 # DefaultCommandPrefix = ''
 
 }
-

--- a/Boxstarter.WinConfig/Disable-BoxstarterBrowserFirstRun.ps1
+++ b/Boxstarter.WinConfig/Disable-BoxstarterBrowserFirstRun.ps1
@@ -1,0 +1,29 @@
+function Disable-BoxstarterBrowserFirstRun {
+    <#
+    .SYNOPSIS
+    Turns off IE and Edge first run customization wizards.
+
+    .LINK
+    https://boxstarter.org
+
+    .EXAMPLE
+    Disable-BrowserFirstRun
+
+    Turns off IE and Edge first run customization wizards.
+    #>
+    $RegistryKeys = @(
+        @{ Key = 'HKLM:\Software\Policies\Microsoft\Edge' ; Value = 'HideFirstRunExperience' } # Edge
+        @{ Key = 'HKLM:\Software\Microsoft\Internet Explorer\Main' ; Value = 'DisableFirstRunCustomize' } # Internet Explorer 11
+        @{ Key = 'HKLM:\Software\Policies\Microsoft\Internet Explorer\Main' ; Value = 'DisableFirstRunCustomize' } # Internet Explorer 9
+    )
+
+    foreach ($Key in $RegistryKeys) {
+        if (-not (Test-Path $Key.Key)) {
+            New-Item -Path $Key.Key -Force
+        }
+
+        New-ItemProperty -Path $Key.Key -Name $Key.Value -Value 1 -PropertyType DWORD -Force
+    }
+
+    Write-Output "IE and Edge first run customizations wizards have been disabled."
+}


### PR DESCRIPTION
## Description Of Changes

Add a function to disable the first run wizards of Microsoft's browsers.

## Motivation and Context

Invoke-WebRequest doesn't work properly until IE is configured. Edge has a long cumbersome first run wizard that many find undesirable.

## Testing

1. Copied the function into a PowerShell 5.1 window on a Windows 10 VM
2. Ran the function in there
3. Verified it worked as intended.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #209 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
