### PR TITLE
(#537) Do not install latest version of Chocolatey when using the WebLauncher

### DIFF
--- a/Boxstarter.Chocolatey/New-PackageFromScript.ps1
+++ b/Boxstarter.Chocolatey/New-PackageFromScript.ps1
@@ -55,7 +55,7 @@ about_boxstarter_chocolatey
     $chocoInstall = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'MACHINE')
     if($chocoInstall -eq $null) {
         # Simply Installs choco repo and helpers
-        Call-Chocolatey -Command 'install' -PackageNames @('chocolatey')
+        Call-Chocolatey -Command '--version'
         $chocoInstall = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'MACHINE')
     }
     if($source -like "*://*"){


### PR DESCRIPTION
fixes GH-537