### PR TITLE
(maint) Add Stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,48 @@
+name: 'Stale Issue and PR Cleanup'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.1.0
+        id: stale
+        with:
+          days-before-stale: 30
+          days-before-close: 14
+          exempt-all-assignees: false
+          exempt-draft-pr: true
+          stale-issue-label: "Pending Closure"
+          stale-pr-label: 'Pending Closure'
+          only-labels: '0 - Waiting on User'
+          close-issue-label: "No Response / Stale"
+          close-pr-label: "No Response / Stale"
+          exempt-issue-labels: 'Security / CVE'
+          exempt-pr-labels: 'Security / CVE'
+          labels-to-remove-when-unstale: '0 - Wating on User,Pending closure'
+          stale-issue-message: |
+            Is this still relevant? If so, what is blocking it? Is there anything you can do to help move it forward?
+            This issue will be closed in 14 days if it continues to be inactive.
+          close-issue-message: |
+            Dear contributor,
+
+            As this issue seems to have been inactive for quite some time now, it has been automatically closed.
+            If you feel this is a valid issue, please feel free to re-open the issue if / when a pull request
+            has been added.
+            Thank you for your contribution.
+
+          close-pr-message: |
+            Dear contributor,
+
+            As this PR seems to have been inactive for 30 days after changes / additional information
+            was requested, it has been automatically closed.
+            If you feel the changes are still valid, please re-open the PR once all changes or additional information
+            that was requested has been added.
+            Thank you for your contribution.


### PR DESCRIPTION
## Description Of Changes
Add's the stale workflow to this repository. Any issue or PR with the label `0 - Waiting on user` will be checked by the workflow.

I have ensured that the Actions are enabled in this repository.

## Motivation and Context
The repository doesn't have this, and we are standardising it across them.

## Testing
This is the same configuration that is used in [chocolatey/choco](https://github.com/chocolatey/choco/blob/develop/.github/workflows/stale.yml).

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
N/A
