### PR TITLE
(#509) Fix CCR API URL

### DIFF
--- a/Boxstarter.Chocolatey/en-US/about_boxstarter_chocolatey.help.txt
+++ b/Boxstarter.Chocolatey/en-US/about_boxstarter_chocolatey.help.txt
@@ -68,7 +68,7 @@ Package Sources
 	directory ($Boxstarter.BaseDir). You can change the default by using the
 	Set-BoxstarterConfig function with the -LocalRepo argument.
 
-	- Chocolatey.org: The public Chocolatey community feed at https://chocolatey.org/api/v2
+	- Chocolatey.org: The public Chocolatey community feed at https://community.chocolatey.org/api/v2
 
 	The last remote source can be configured by editing
 	$($Boxstarter.BaseDir)\Boxstarter.Config.

--- a/Boxstarter.TestRunner/Get-BoxstarterDeployOptions.ps1
+++ b/Boxstarter.TestRunner/Get-BoxstarterDeployOptions.ps1
@@ -25,7 +25,7 @@ Set-BoxstarterDeployOptions
             DeploymentVMProvider=$null
             DeploymentCloudServiceName=$null
             RestoreCheckpoint=$null
-            DefaultNugetFeed=[Uri]"https://chocolatey.org/api/v2"
+            DefaultNugetFeed=[Uri]"https://community.chocolatey.org/api/v2"
             DefaultFeedAPIKey=$null
         }
     }

--- a/Boxstarter.TestRunner/Get-BoxstarterFeedAPIKey.ps1
+++ b/Boxstarter.TestRunner/Get-BoxstarterFeedAPIKey.ps1
@@ -15,7 +15,7 @@ a key to be associated with a feed.
 The URI of a NuGet feed for which the API key is being queried.
 
 .Example
-Get-BoxstarterFeedAPIKey "https://chocolatey.org/api/v2"
+Get-BoxstarterFeedAPIKey "https://community.chocolatey.org/api/v2"
 
 Retrieves the API Key used with the public Chocolatey community feed
 

--- a/Boxstarter.TestRunner/Set-BoxstarterFeedAPIKey.ps1
+++ b/Boxstarter.TestRunner/Set-BoxstarterFeedAPIKey.ps1
@@ -21,7 +21,7 @@ The GUID API Key to assiciate with the feed.
 These keys are persisted to a file in encrypted format.
 
 .Example
-Set-BoxstarterFeedAPIKey -NugetFeed "https://chocolatey.org/api/v2" `
+Set-BoxstarterFeedAPIKey -NugetFeed "https://community.chocolatey.org/api/v2" `
   -APIKey 5cbc38d9-1a94-430d-8361-685a9080a6b8
 
 Sets the API Key used with the public Chocolatey community feed to

--- a/Boxstarter.config
+++ b/Boxstarter.config
@@ -1,5 +1,5 @@
 <config>
-  <ChocolateyPackage>https://chocolatey.org/api/v2/package/chocolatey/0.9.8.33</ChocolateyPackage>
+  <ChocolateyPackage>https://community.chocolatey.org/api/v2/package/chocolatey/0.9.8.33</ChocolateyPackage>
   <ChocolateyRepo>https://chocolatey.org/install.ps1</ChocolateyRepo>
-  <NugetSources>https://chocolatey.org/api/v2</NugetSources>
+  <NugetSources>https://community.chocolatey.org/api/v2</NugetSources>
 </config>

--- a/BuildScripts/bootstrapper.ps1
+++ b/BuildScripts/bootstrapper.ps1
@@ -82,7 +82,7 @@ function Check-Chocolatey {
             }
             try {
                 $env:ChocolateyInstall = "$env:programdata\chocolatey"
-                $url="https://chocolatey.org/api/v2/package/chocolatey/"
+                $url="https://community.chocolatey.org/api/v2/package/chocolatey/"
                 $wc=new-object net.webclient
                 $wp=[system.net.WebProxy]::GetDefaultProxy()
                 $wp.UseDefaultCredentials=$true

--- a/tests/TestRunner/Get-BoxstarterDeployOptions.Tests.ps1
+++ b/tests/TestRunner/Get-BoxstarterDeployOptions.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Get-BoxstarterDeployOptions" {
         $result = Get-BoxstarterDeployOptions
 
         it "should return the Chocolatey community feed as the default NuGet feed" {
-            $result.DefaultNugetFeed | should be "https://chocolatey.org/api/v2"
+            $result.DefaultNugetFeed | should be "https://community.chocolatey.org/api/v2"
         }
         it "should return localhost as the default deployment target" {
             $result.DeploymentTargetNames | should be "localhost"


### PR DESCRIPTION
## Description Of Changes
Replaced the old Chocolatey Community Repository URL `https://chocolatey.org/api/v2` with the correct one `https://community.chocolatey.org/api/v2`

## Motivation and Context
Some parts of Boxstarter still referencing the old URL.

## Testing

This was a straight string change from one to the other, so no testing has been done. The old URL simply redirects to the correct one. The only change will be one less hop top go through.

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #509 