### PR TITLE
(#506) Remove choco aliases

### DIFF
--- a/Boxstarter.Chocolatey/Get-PackageRoot.ps1
+++ b/Boxstarter.Chocolatey/Get-PackageRoot.ps1
@@ -24,7 +24,7 @@ Invoke-ChocolateyBoxstarter MyPackage
 
 --ChocolateyInstall.ps1--
 try {
-    cinst sublimetext2
+    choco install sublimetext2
     $sublimeDir = "$env:programfiles\Sublime Text 2"
     mkdir "$sublimeDir\data"
     copy-item (Join-Path Get-PackageRoot($MyInvocation) 'sublime\*') "$sublimeDir\data" -Force -Recurse

--- a/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
+++ b/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
@@ -106,7 +106,7 @@ If specifying only one package, Boxstarter calls Chocolatey with the
 This means that regardless of whether or not the package had been
 installed previously, Boxstarter will attempt to download and reinstall it.
 This only holds true for the outer package. If the package contains calls
-to CINST for additional packages, those installs will not reinstall if
+to choco install for additional packages, those installs will not reinstall if
 previously installed.
 
 If an array of package names are passed to Install-BoxstarterPackage,

--- a/Boxstarter.Chocolatey/Invoke-BoxstarterFromTask.ps1
+++ b/Boxstarter.Chocolatey/Invoke-BoxstarterFromTask.ps1
@@ -8,12 +8,12 @@ Creates the script necessary for a scheduled task to run the given command. The 
 task will run immediately.
 
 .PARAMETER Command
-A Chocolatey command to execute within a scheduled task. For example "cinst fiddler".
+A Chocolatey command to execute within a scheduled task. For example "choco install fiddler".
 
 .EXAMPLE
 A Chocolatey command
 
-Invoke-BoxstarterFromTask "cinst rsat"
+Invoke-BoxstarterFromTask "choco install rsat"
 
 .LINK
 https://boxstarter.org

--- a/Boxstarter.Chocolatey/Invoke-ChocolateyBoxstarter.ps1
+++ b/Boxstarter.Chocolatey/Invoke-ChocolateyBoxstarter.ps1
@@ -59,7 +59,7 @@ If specifying only one package, Boxstarter calls Chocolatey with the
 This means that regardless of whether or not the package had been
 installed previously, Boxstarter will attempt to download and reinstall it.
 This only holds true for the outer package. If the package contains calls
-to CINST for additional packages, those installs will not reinstall if
+to choco install for additional packages, those installs will not reinstall if
 previously installed.
 
 If an array of package names are passed to Invoke-ChocolateyBoxstarter,

--- a/Boxstarter.Chocolatey/en-US/about_boxstarter_chocolatey.help.txt
+++ b/Boxstarter.Chocolatey/en-US/about_boxstarter_chocolatey.help.txt
@@ -60,7 +60,7 @@ Consuming Boxstarter Packages
 
 Package Sources
 	Install-BoxstarterPackage (or Boxstarter) expects just the name of the
-	bootstrapping package - just like CINST or NuGet. Boxstarter will search
+	bootstrapping package - just like choco install or NuGet. Boxstarter will search
 	the following locations in this order:
 
 	- $Boxstarter.LocalRepo: This is the local repository that by default is
@@ -120,7 +120,7 @@ Package Authoring Considerations
 	twice.
 
 	- If you have several Chocolatey packages that you want to install
-	during the Boxstarter session, it is preferable to call CINST
+	during the Boxstarter session, it is preferable to call choco install
 	directly from inside your ChocolateyInstall instead of declaring
 	them as dependencies. This is because Boxstarter cannot intercept
 	Chocolatey dependencies so those packages will not have any reboot

--- a/Boxstarter.TestRunner/en-US/about_Boxstarter_TestRunner.help.txt
+++ b/Boxstarter.TestRunner/en-US/about_Boxstarter_TestRunner.help.txt
@@ -132,7 +132,7 @@ Configuring a Dedicated Build Server
     ACCOUNT that your build server runs under.
 
     1. Install the Boxstarter TestRunner module on the build machine. You can
-       use Chocolatey and run cinst Boxstarter.TestRunner or launch
+       use Chocolatey and run choco install Boxstarter.TestRunner or launch
        https://boxstarter.org/package/nr/boxstarter.testrunner from IE.
     2. Although many of the deployment options are stored in a file inside the
        repository and will be available when your build server gets the latest

--- a/BuildPackages/example-light/tools/chocolateyInstall.ps1
+++ b/BuildPackages/example-light/tools/chocolateyInstall.ps1
@@ -2,10 +2,10 @@ Update-ExecutionPolicy Unrestricted
 Set-ExplorerOptions -showHiddenFilesFoldersDrives -showProtectedOSFiles -showFileExtensions
 Enable-RemoteDesktop
 
-cinst console-devel
-cinst sublimetext2
-cinst sysinternals
-cinst TelnetClient -source windowsFeatures
+choco install console-devel
+choco install sublimetext2
+choco install sysinternals
+choco install TelnetClient -source windowsFeatures
 
 $sublimeDir = "$env:programfiles\Sublime Text 2"
 

--- a/BuildPackages/example/tools/chocolateyInstall.ps1
+++ b/BuildPackages/example/tools/chocolateyInstall.ps1
@@ -7,7 +7,7 @@ try {
     Set-TaskbarSmall
     Enable-RemoteDesktop
 
-    cinst VisualStudio2012Ultimate
+    choco install VisualStudio2012Ultimate
 
     try{
         $devenv = Get-Item "$($Boxstarter.programFiles86)\Microsoft Visual Studio 11.0\Common7\IDE\devenv.exe" -ErrorAction SilentlyContinue
@@ -17,29 +17,29 @@ try {
         }
     }catch{}
 
-    cinst fiddler4
-    cinst mssqlserver2012express
-    cinst git-credential-winstore
-    cinst console-devel
-    cinst sublimetext2
-    cinst skydrive
-    cinst poshgit
-    cinst dotpeek
-    cinst googlechrome
-    cinst Paint.net
-    cinst windirstat
-    cinst sysinternals
-    cinst NugetPackageExplorer
-    cinst resharper
-    cinst winrar
-    cinst windbg
+    choco install fiddler4
+    choco install mssqlserver2012express
+    choco install git-credential-winstore
+    choco install console-devel
+    choco install sublimetext2
+    choco install skydrive
+    choco install poshgit
+    choco install dotpeek
+    choco install googlechrome
+    choco install Paint.net
+    choco install windirstat
+    choco install sysinternals
+    choco install NugetPackageExplorer
+    choco install resharper
+    choco install winrar
+    choco install windbg
 
-    cinst Microsoft-Hyper-V-All -source windowsFeatures
-    cinst IIS-WebServerRole -source windowsfeatures
-    cinst IIS-HttpCompressionDynamic -source windowsfeatures
-    cinst IIS-ManagementScriptingTools -source windowsfeatures
-    cinst IIS-WindowsAuthentication -source windowsfeatures
-    cinst TelnetClient -source windowsFeatures
+    choco install Microsoft-Hyper-V-All -source windowsFeatures
+    choco install IIS-WebServerRole -source windowsfeatures
+    choco install IIS-HttpCompressionDynamic -source windowsfeatures
+    choco install IIS-ManagementScriptingTools -source windowsfeatures
+    choco install IIS-WindowsAuthentication -source windowsfeatures
+    choco install TelnetClient -source windowsFeatures
 
     $sublimeDir = "$env:programfiles\Sublime Text 2"
     Install-ChocolateyPinnedTaskBarItem "$env:windir\system32\mstsc.exe"

--- a/BuildPackages/test-package/tools/chocolateyInstall.ps1
+++ b/BuildPackages/test-package/tools/chocolateyInstall.ps1
@@ -4,8 +4,8 @@ try {
     }
 
     Write-boxstartermessage "installing test package"
-    cinst TelnetClient -source WindowsFeatures
-    cinst force-reboot
+    choco install TelnetClient -source WindowsFeatures
+    choco install force-reboot
 
     if($PSVersionTable.PSVersion -gt '2.0.0' -and ([bool]::Parse($env:IsRemote))) {
         cinst windirstat

--- a/BuildScripts/BoxstarterChocolateyInstall.ps1
+++ b/BuildScripts/BoxstarterChocolateyInstall.ps1
@@ -1,6 +1,6 @@
 try {
     Write-Host "To load all Boxstarter Modules immediately, just enter 'BoxstarterShell'." -ForegroundColor Yellow
-    Write-Host "Interested in Windows Azure VM integration? Run CINST Boxstarter.Azure to install Boxstarter's Azure integration."
+    Write-Host "Interested in Windows Azure VM integration? Run choco install Boxstarter.Azure to install Boxstarter's Azure integration."
 } catch {
     throw $_.exception
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The source of the Boxstarter website can be found in the [boxstarter.org reposit
 Import-Module Boxstarter.Chocolatey
 New-BoxstarterPackage HelloWorld
 Set-Content (Join-Path $Boxstarter.LocalRepo "HelloWorld\Tools\ChocolateyInstall.ps1") `
-  -Value "Write-Host `"Hello World! from `$env:COMPUTERNAME`";CINST Git" -Force
+  -Value "Write-Host `"Hello World! from `$env:COMPUTERNAME`";choco install Git" -Force
 Invoke-BoxstarterBuild HelloWorld
 ```
 


### PR DESCRIPTION
## Description Of Changes
Replaced the `cinst`, `cpush` and `cup` aliases, where it makes sense, with the Chocolatey CLI commands.

## Motivation and Context
Chocolatey CLI no longer ships with choco alias shims, so these will no longer work. Boxstarter does include functions called `cinst` and `cup` so they will still work with Boxstarter scripts. However, we want to make sure users utilise the full commands now, so we should talk about those explicitly.

The `cinst` and `cup` functions were simply shortcuts and called the correct function directly with the `install` or `upgrade` parameter. So nothing changes.

## Testing
Most of this was documentation changes and a few commands. Nothing functionally chances.

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #506 