### PR TITLE
(GH-560) ensure description of pkg is ccr compatible

### DIFF
--- a/Boxstarter.Chocolatey/New-BoxstarterPackage.ps1
+++ b/Boxstarter.Chocolatey/New-BoxstarterPackage.ps1
@@ -72,7 +72,10 @@ Get-PackageRoot
     <version>1.0.0</version>
     <authors></authors>
     <owners></owners>
-    <description>Package description</description>
+    <projectUrl>https://boxstarter.org</projectUrl>
+    <description>
+Package description, should be longer than 19 characters to pass CCR package validator
+    </description>
     <tags>Tag1 Tag2</tags>
   </metadata>
 </package>

--- a/tests/Chocolatey/New-BoxstarterPackage.tests.ps1
+++ b/tests/Chocolatey/New-BoxstarterPackage.tests.ps1
@@ -12,7 +12,7 @@ Describe "New-BoxstarterPackage" {
     $Boxstarter.LocalRepo=Join-Path $boxstarter.BaseDir "repo"
     $Boxstarter.SuppressLogging=$true
     $packageName="pkg"
-    $Description="My Description"
+    $Description="My Description that is long enough to pass the package validator"
     Context "When No Path is provided" {
         New-BoxstarterPackage $packageName $Description | Out-Null
 


### PR DESCRIPTION
## Description Of Changes

Ensure all requirements of CCR validator are met when creating packages via Boxstarter.

## Motivation and Context

With this change, it is possible to use Boxstarter when chocolatey-community-validation.Extension is installed

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #560 
