### PR TITLE
(GH-564) ensure ExitCode is populated

### DIFF
--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -87,7 +87,9 @@ function Invoke-Chocolatey($chocoArgs) {
             
             $p = Start-Process @pargs
 
+            $dummy = $p.Handle # Cache the handle => https://github.com/PowerShell/PowerShell/issues/20400
             Wait-Process -Id $p.Id
+            Write-Verbose "choco process handle: $dummy"
             
             Write-BoxstarterMessage "BoxstarterWrapper::Run => $($p.ExitCode)" -Verbose
             [System.Environment]::ExitCode = $p.ExitCode


### PR DESCRIPTION
## Description Of Changes

Hold on handle of created process to ensure 'ExitCode' get's correctly populated.
See https://github.com/PowerShell/PowerShell/issues/20400

## Testing

Tested on Server2019 Vagrant VM, works

![image](https://github.com/chocolatey/boxstarter/assets/5354972/70a7226b-d9a0-41ba-8e95-2010a912f18c)


## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #564
