### PR TITLE
Boxstarter only modifys UAC level

### DIFF
--- a/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
+++ b/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
@@ -2,7 +2,7 @@ function Cleanup-Boxstarter {
     param(
         [switch]$KeepWindowOpen,
         [switch]$DisableRestart)
-    if(Get-IsRemote){
+    if (Get-IsRemote) {
         Remove-BoxstarterTask
     }
     Start-UpdateServices
@@ -13,51 +13,71 @@ function Cleanup-Boxstarter {
         Remove-Item "$(Join-Path $env:temp 'Boxstarter.ext.*')" -Force -ErrorAction SilentlyContinue
     }
 
-    if(Test-Path "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC") {
-        del "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC"
+    if (Test-Path "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC") {
+        $uacLevel = Get-Content "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC"
+        Remove-Item "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC"
         Enable-UAC
-    }
-    if(!$Boxstarter.IsRebooting) {
-        Write-BoxstarterMessage "Cleaning up and not rebooting" -Verbose
-        $startup = "$env:appdata\Microsoft\Windows\Start Menu\Programs\Startup"
-        if( Test-Path "$Startup\boxstarter-post-restart.bat") {
-            Write-BoxstarterMessage "Cleaning up restart file" -Verbose
-            remove-item "$Startup\boxstarter-post-restart.bat"
-            remove-item "$(Get-BoxstarterTempDir)\Boxstarter.Script"
-            $promptToExit=$true
+        if ($uacLevel) {
+            Set-BoxstarterConsentPromptBehaviorAdmin -ConsentPromptBehaviorAdmin $uacLevel
+            Write-BoxstarterMessage "Re-enabled UAC with ConsentPromptBehaviorAdmin set to $uacLevel"
         }
-        if(Test-Path "$(Get-BoxstarterTempDir)\Boxstarter.autologon") {
-            Write-BoxstarterMessage "Cleaning up autologon registry keys" -Verbose
-            $winLogonKey="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
-            $winlogonProps = Import-CLIXML -Path "$(Get-BoxstarterTempDir)\Boxstarter.autologon"
-            @("DefaultUserName","DefaultDomainName","DefaultPassword","AutoAdminLogon") | % {
-                if(!$winlogonProps.ContainsKey($_)){
-                  Remove-ItemProperty -Path $winLogonKey -Name $_ -ErrorAction SilentlyContinue
+    }
+    if (!$Boxstarter.IsRebooting) {
+        Write-BoxstarterMessage 'Cleaning up and not rebooting' -Verbose
+        $startup = "$env:appdata\Microsoft\Windows\Start Menu\Programs\Startup"
+        if ( Test-Path "$Startup\boxstarter-post-restart.bat") {
+            Write-BoxstarterMessage 'Cleaning up restart file' -Verbose
+            Remove-Item "$Startup\boxstarter-post-restart.bat"
+            Remove-Item "$(Get-BoxstarterTempDir)\Boxstarter.Script"
+            $promptToExit = $true
+        }
+        if (Test-Path "$(Get-BoxstarterTempDir)\Boxstarter.autologon") {
+            Write-BoxstarterMessage 'Cleaning up autologon registry keys' -Verbose
+            $winLogonKey = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
+            $winlogonProps = Import-Clixml -Path "$(Get-BoxstarterTempDir)\Boxstarter.autologon"
+            @('DefaultUserName', 'DefaultDomainName', 'DefaultPassword', 'AutoAdminLogon') | ForEach-Object {
+                if (!$winlogonProps.ContainsKey($_)) {
+                    Remove-ItemProperty -Path $winLogonKey -Name $_ -ErrorAction SilentlyContinue
                 }
                 else {
-                  Set-ItemProperty -Path $winLogonKey -Name $_ -Value $winlogonProps[$_]
+                    Set-ItemProperty -Path $winLogonKey -Name $_ -Value $winlogonProps[$_]
                 }
             }
             Remove-Item -Path "$(Get-BoxstarterTempDir)\Boxstarter.autologon"
         }
-        if($promptToExit -or $KeepWindowOpen){
+        if ($promptToExit -or $KeepWindowOpen) {
             Read-Host 'Type ENTER to exit'
         }
         return
     }
 
-    if(!(Get-IsRemote -PowershellRemoting) -and !$DisableRestart){
-        if(Get-UAC){
-            Write-BoxstarterMessage "UAC Enabled. Disabling..."
-            Disable-UAC
-            New-Item "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC" -type file | Out-Null
+    if (!(Get-IsRemote -PowershellRemoting) -and !$DisableRestart) {
+        if (Get-UAC) {
+            Write-BoxstarterMessage 'UAC Enabled. Disabling...'
+            # only _disable_ UAC prior to Win2016
+            # Windows Server 2016 is version 10.0.14393
+            $minVersion = [version]'10.0.14393'
+            $currentVersion = [System.Environment]::OSVersion.Version
+
+            if ($currentVersion -lt $minVersion) {
+                Write-Output 'Windows version is less than Windows Server 2016.'
+                Disable-UAC
+            }
+            else {
+                Write-Output 'Windows version is Windows Server 2016 or newer.'
+            }
+            $uacLevel = Get-BoxstarterConsentPromptBehaviorAdmin
+            if (-Not (Test-Path "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC")) {
+                Set-Content "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC" $uacLevel
+            }
+            Set-BoxstarterConsentPromptBehaviorAdmin -ConsentPromptBehaviorAdmin 'NeverNotify'
         }
     }
 
-    if(!(Get-IsRemote -PowershellRemoting) -and $BoxstarterPassword.Length -gt 0) {
-        $currentUser=Get-CurrentUser
+    if (!(Get-IsRemote -PowershellRemoting) -and $BoxstarterPassword.Length -gt 0) {
+        $currentUser = Get-CurrentUser
         Write-BoxstarterMessage "Securely Storing $($currentUser.Domain)\$($currentUser.Name) credentials for automatic logon"
         Set-SecureAutoLogon $currentUser.Name $BoxstarterPassword $currentUser.Domain -BackupFile "$(Get-BoxstarterTempDir)\Boxstarter.autologon"
-        Write-BoxstarterMessage "Logon Set"
+        Write-BoxstarterMessage 'Logon Set'
     }
 }

--- a/Boxstarter.Bootstrapper/Invoke-Reboot.ps1
+++ b/Boxstarter.Bootstrapper/Invoke-Reboot.ps1
@@ -1,5 +1,5 @@
 function Invoke-Reboot {
-<#
+    <#
 .SYNOPSIS
 Reboots the local machine ensuring Boxstarter restarts
 automatically after reboot and sets up autologon if it a
@@ -27,34 +27,37 @@ Invoke-Boxstarter
 about_boxstarter_bootstrapper
 about_boxstarter_variable_in_bootstrapper
 #>
-    if(!$Boxstarter.RebootOk) {
+    if (!$Boxstarter.RebootOk) {
         Write-BoxstarterMessage "A Reboot was requested but Reboots are suppressed. Either call Invoke-Boxstarter with -RebootOk or set `$Boxstarter.RebootOk to `$true"
         return
     }
-    if(!(Get-IsRemote -PowershellRemoting) -and !($Boxstarter.DisableRestart)){
-        if(!$Boxstarter.ScriptToCall) {
-            Write-BoxstarterMessage "Invoke-Reboot must be called from a Boxstarter package."
+    if (!(Get-IsRemote -PowershellRemoting) -and !($Boxstarter.DisableRestart)) {
+        if (!$Boxstarter.ScriptToCall) {
+            Write-BoxstarterMessage 'Invoke-Reboot must be called from a Boxstarter package.'
             return
         }
-        Write-BoxstarterMessage "writing restart file"
-        New-Item "$(Get-BoxstarterTempDir)\Boxstarter.script" -type file -value $boxstarter.ScriptToCall -force | Out-Null
+        Write-BoxstarterMessage 'writing restart file'
+        New-Item "$(Get-BoxstarterTempDir)\Boxstarter.script" -type file -Value $boxstarter.ScriptToCall -Force | Out-Null
         $startup = "$env:appdata\Microsoft\Windows\Start Menu\Programs\Startup"
-        $restartScript="Call PowerShell -NoProfile -ExecutionPolicy bypass -command `"Import-Module '$($Boxstarter.BaseDir)\Boxstarter.Bootstrapper\boxstarter.bootstrapper.psd1';Invoke-Boxstarter -RebootOk -NoPassword:`$$($Boxstarter.NoPassword.ToString())`""
-        New-Item "$startup\boxstarter-post-restart.bat" -type file -force -value $restartScript | Out-Null
+
+        # create the restart script
+        # no need to elevate here, Invoke-Bxstarter will Test-Admin and elevate if necessary
+        $restartScript = "Call PowerShell -NoProfile -ExecutionPolicy bypass -command `"Import-Module '$($Boxstarter.BaseDir)\Boxstarter.Bootstrapper\boxstarter.bootstrapper.psd1';Invoke-Boxstarter -RebootOk -NoPassword:`$$($Boxstarter.NoPassword.ToString())`""
+        New-Item "$startup\boxstarter-post-restart.bat" -type file -Force -Value $restartScript | Out-Null
     }
     try {
-        if(Get-Module Bitlocker -ListAvailable -ErrorAction Stop){
-            Get-BitlockerVolume -ErrorAction Stop | ? {$_.ProtectionStatus -eq "On"  -and $_.VolumeType -eq "operatingSystem"} | Suspend-Bitlocker -RebootCount 1 | Out-Null
+        if (Get-Module Bitlocker -ListAvailable -ErrorAction Stop) {
+            Get-BitlockerVolume -ErrorAction Stop | Where-Object { $_.ProtectionStatus -eq 'On' -and $_.VolumeType -eq 'operatingSystem' } | Suspend-Bitlocker -RebootCount 1 | Out-Null
         }
     }
     catch {
         $Global:Error.RemoveAt(0)
     } # There are several reports of the bitlocker module throwing errors
-    $Boxstarter.IsRebooting=$true
+    $Boxstarter.IsRebooting = $true
 
-    if($Boxstarter.SourcePID -ne $Null) {
+    if ($Boxstarter.SourcePID -ne $Null) {
         Write-BoxstarterMessage "Writing restart marker with pid $($Boxstarter.SourcePID) from $PID" -verbose
-        New-Item "$(Get-BoxstarterTempDir)\Boxstarter.$($Boxstarter.SourcePID).restart" -type file -value "" -force | Out-Null
+        New-Item "$(Get-BoxstarterTempDir)\Boxstarter.$($Boxstarter.SourcePID).restart" -type file -Value '' -Force | Out-Null
     }
     Restart
 }

--- a/Boxstarter.Bootstrapper/Invoke-Reboot.ps1
+++ b/Boxstarter.Bootstrapper/Invoke-Reboot.ps1
@@ -41,7 +41,7 @@ about_boxstarter_variable_in_bootstrapper
         $startup = "$env:appdata\Microsoft\Windows\Start Menu\Programs\Startup"
 
         # create the restart script
-        # no need to elevate here, Invoke-Bxstarter will Test-Admin and elevate if necessary
+        # no need to elevate here, Invoke-Boxstarter will Test-Admin and elevate if necessary
         $restartScript = "Call PowerShell -NoProfile -ExecutionPolicy bypass -command `"Import-Module '$($Boxstarter.BaseDir)\Boxstarter.Bootstrapper\boxstarter.bootstrapper.psd1';Invoke-Boxstarter -RebootOk -NoPassword:`$$($Boxstarter.NoPassword.ToString())`""
         New-Item "$startup\boxstarter-post-restart.bat" -type file -Force -Value $restartScript | Out-Null
     }

--- a/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
+++ b/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
@@ -785,7 +785,7 @@ function Invoke-RemoteBoxstarter($Package, $Credential, $DisableReboots, $sessio
             if($Boxstarter.IsRebooting){
                 $resultToReturn.Result="Rebooting"
             }
-            elseif($result=$true){
+            elseif($result -eq $true){
                 $resultToReturn.Result="Completed"
             }
             $resultToReturn.Errors = $Global:Error

--- a/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
+++ b/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
@@ -339,7 +339,7 @@ about_boxstarter_chocolatey
             $sessionArgs.Credential=$Credential
         }
 
-				$delegateSources = if ($DelegateChocoSources) { $true} else { $false }
+        $delegateSources = if ($DelegateChocoSources) { $true} else { $false }
 
         #If $sessions are being provided we assume remoting is setup on both ends
         #and don't need to test, configure and tear down

--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psd1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psd1
@@ -48,7 +48,9 @@ CmdletsToExport = @(
   'Set-BoxstarterTaskbarOptions',
   'Disable-BingSearch', 
   'Set-BoxstarterPageFile', 
-  'Disable-BoxstarterBrowserFirstRun'
+  'Disable-BoxstarterBrowserFirstRun',
+  'Get-BoxstarterConsentPromptBehaviorAdmin',
+  'Set-BoxstarterConsentPromptBehaviorAdmin'
 )
 
 # Variables to export from this module

--- a/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -1,0 +1,31 @@
+function Get-BoxstarterConsentPromptBehaviorAdmin {
+    <#
+https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/341747f5-6b5d-4d30-85fc-fa1cc04038d4
+
+	
+0x00000000 -> "NeverNotify"
+0x00000001 -> "NotifyOnAppInstallWithoutDimming"
+0x00000002 -> "NotifyOnAppInstall"
+0x00000003 -> "PromptForConsent"
+0x00000004 -> "PromptForCredentials"
+0x00000005 -> "AlwaysNotify"
+    #>
+
+    $state = Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name ConsentPromptBehaviorAdmin -ErrorAction SilentlyContinue
+    if ($null -eq $state) {  
+        Write-BoxstarterMessage "ConsentPromptBehaviorAdmin is not set. Defaulting to 'AlwaysNotify'."
+        return 'AlwaysNotify'
+    }
+    switch ($state.ConsentPromptBehaviorAdmin) {
+        0 { return 'NeverNotify' }
+        1 { return 'NotifyOnAppInstallWithoutDimming' }
+        2 { return 'NotifyOnAppInstall' }
+        3 { return 'PromptForConsent' }
+        4 { return 'PromptForCredentials' }
+        5 { return 'AlwaysNotify' }
+        default {
+            Write-BoxstarterMessage "Unknown ConsentPromptBehaviorAdmin value: $($state.ConsentPromptBehaviorAdmin). Defaulting to 'AlwaysNotify'."
+            return 'AlwaysNotify'
+        }
+    }
+}

--- a/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -18,7 +18,7 @@ function Get-BoxstarterConsentPromptBehaviorAdmin {
     }
 
     $stateAdmin = Get-ItemProperty -Path $hklmuac -Name ConsentPromptBehaviorAdmin -ErrorAction SilentlyContinue
-    if ($null -eq $stateAdmin) {  
+    if ($null -eq $stateAdmin) {
         Write-BoxstarterMessage "ConsentPromptBehaviorAdmin is not set. Defaulting to 'AlwaysNotify'."
         return 'AlwaysNotify'
     }
@@ -26,7 +26,7 @@ function Get-BoxstarterConsentPromptBehaviorAdmin {
     $statePrompt = Get-ItemProperty -Path $hklmuac -Name PromptOnSecureDesktop -ErrorAction SilentlyContinue
     switch ($stateAdmin.ConsentPromptBehaviorAdmin) {
         0 { return 'NeverNotify' }
-        5 { 
+        5 {
             if ($statePrompt.PromptOnSecureDesktop -eq 0) {
                 return 'NotifyOnAppInstallWithoutDimming'
             }

--- a/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -2,13 +2,6 @@ function Get-BoxstarterConsentPromptBehaviorAdmin {
     <#
 https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/341747f5-6b5d-4d30-85fc-fa1cc04038d4
 
-	
-0x00000000 -> "NeverNotify"
-0x00000001 -> "NotifyOnAppInstallWithoutDimming"
-0x00000002 -> "NotifyOnAppInstall"
-0x00000003 -> "PromptForConsent"
-0x00000004 -> "PromptForCredentials"
-0x00000005 -> "AlwaysNotify"
     #>
 
     $state = Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name ConsentPromptBehaviorAdmin -ErrorAction SilentlyContinue
@@ -18,11 +11,9 @@ https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/341747f5-6
     }
     switch ($state.ConsentPromptBehaviorAdmin) {
         0 { return 'NeverNotify' }
-        1 { return 'NotifyOnAppInstallWithoutDimming' }
-        2 { return 'NotifyOnAppInstall' }
-        3 { return 'PromptForConsent' }
-        4 { return 'PromptForCredentials' }
-        5 { return 'AlwaysNotify' }
+        # 5 { return 'NotifyOnAppInstallWithoutDimming' }
+        5 { return 'NotifyOnAppInstall' }
+        2 { return 'AlwaysNotify' }
         default {
             Write-BoxstarterMessage "Unknown ConsentPromptBehaviorAdmin value: $($state.ConsentPromptBehaviorAdmin). Defaulting to 'AlwaysNotify'."
             return 'AlwaysNotify'

--- a/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Get-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -1,21 +1,40 @@
+<#
+.SYNOPSIS
+Retrieves the User Account Control (UAC) consent prompt behavior.
+
+.LINK
+https://boxstarter.org
+Set-BoxstarterConsentPromptBehaviorAdmin
+#>
 function Get-BoxstarterConsentPromptBehaviorAdmin {
-    <#
-https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/341747f5-6b5d-4d30-85fc-fa1cc04038d4
+    [CmdletBinding()]
 
-    #>
+    $hklmuac = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
 
-    $state = Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name ConsentPromptBehaviorAdmin -ErrorAction SilentlyContinue
-    if ($null -eq $state) {  
+    $uacState = Get-ItemProperty -Path $hklmuac -Name EnableLUA -ErrorAction SilentlyContinue
+    if ($null -eq $uacState) {
+        # UAC is disable -> consent prompt behavior is irrelevant
+        return $null
+    }
+
+    $stateAdmin = Get-ItemProperty -Path $hklmuac -Name ConsentPromptBehaviorAdmin -ErrorAction SilentlyContinue
+    if ($null -eq $stateAdmin) {  
         Write-BoxstarterMessage "ConsentPromptBehaviorAdmin is not set. Defaulting to 'AlwaysNotify'."
         return 'AlwaysNotify'
     }
-    switch ($state.ConsentPromptBehaviorAdmin) {
+
+    $statePrompt = Get-ItemProperty -Path $hklmuac -Name PromptOnSecureDesktop -ErrorAction SilentlyContinue
+    switch ($stateAdmin.ConsentPromptBehaviorAdmin) {
         0 { return 'NeverNotify' }
-        # 5 { return 'NotifyOnAppInstallWithoutDimming' }
-        5 { return 'NotifyOnAppInstall' }
+        5 { 
+            if ($statePrompt.PromptOnSecureDesktop -eq 0) {
+                return 'NotifyOnAppInstallWithoutDimming'
+            }
+            return 'NotifyOnAppInstall'
+        }
         2 { return 'AlwaysNotify' }
         default {
-            Write-BoxstarterMessage "Unknown ConsentPromptBehaviorAdmin value: $($state.ConsentPromptBehaviorAdmin). Defaulting to 'AlwaysNotify'."
+            Write-BoxstarterMessage "Unknown ConsentPromptBehaviorAdmin value: $($stateAdmin.ConsentPromptBehaviorAdmin). Defaulting to 'AlwaysNotify'."
             return 'AlwaysNotify'
         }
     }

--- a/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -1,0 +1,41 @@
+function Set-BoxstarterConsentPromptBehaviorAdmin {
+    <#
+.SYNOPSIS
+Sets the User Account Control (UAC) consent prompt behavior to specified value.
+
+https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/341747f5-6b5d-4d30-85fc-fa1cc04038d4
+
+	
+0x00000000 -> "NeverNotify"
+0x00000001 -> "NotifyOnAppInstallWithoutDimming"
+0x00000002 -> "NotifyOnAppInstall"
+0x00000003 -> "PromptForConsent"
+0x00000004 -> "PromptForCredentials" 
+0x00000005 -> "AlwaysNotify"
+
+.LINK
+https://boxstarter.org
+
+#>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $True)]
+        [Validateset('NeverNotify', 'NotifyOnAppInstallWithoutDimming', 'NotifyOnAppInstall', 'PromptForConsent', 'PromptForCredentials', 'AlwaysNotify')]
+        [string]
+        $ConsentPromptBehavior
+    )
+    $value = switch ($ConsentPromptBehavior) {
+        'NeverNotify' { 0 }
+        'NotifyOnAppInstallWithoutDimming' { 1 }
+        'NotifyOnAppInstall' { 2 }
+        'PromptForConsent' { 3 }
+        'PromptForCredentials' { 4 }
+        'AlwaysNotify' { 5 }
+    }
+    Write-BoxstarterMessage "Setting ConsentPromptBehaviorAdmin to $ConsentPromptBehavior"
+    Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
+        -Name ConsentPromptBehaviorAdmin `
+        -Value $value `
+        -Type DWord `
+        -Force
+}

--- a/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -5,14 +5,6 @@ Sets the User Account Control (UAC) consent prompt behavior to specified value.
 
 https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/341747f5-6b5d-4d30-85fc-fa1cc04038d4
 
-	
-0x00000000 -> "NeverNotify"
-0x00000001 -> "NotifyOnAppInstallWithoutDimming"
-0x00000002 -> "NotifyOnAppInstall"
-0x00000003 -> "PromptForConsent"
-0x00000004 -> "PromptForCredentials" 
-0x00000005 -> "AlwaysNotify"
-
 .LINK
 https://boxstarter.org
 
@@ -26,11 +18,9 @@ https://boxstarter.org
     )
     $value = switch ($ConsentPromptBehavior) {
         'NeverNotify' { 0 }
-        'NotifyOnAppInstallWithoutDimming' { 1 }
-        'NotifyOnAppInstall' { 2 }
-        'PromptForConsent' { 3 }
-        'PromptForCredentials' { 4 }
-        'AlwaysNotify' { 5 }
+        # 'NotifyOnAppInstallWithoutDimming' { 5 }
+        'NotifyOnAppInstall' { 5 }
+        'AlwaysNotify' { 2 }
     }
     Write-BoxstarterMessage "Setting ConsentPromptBehaviorAdmin to $ConsentPromptBehavior"
     Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `

--- a/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -1,31 +1,40 @@
-function Set-BoxstarterConsentPromptBehaviorAdmin {
-    <#
+<#
 .SYNOPSIS
 Sets the User Account Control (UAC) consent prompt behavior to specified value.
 
-https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsb/341747f5-6b5d-4d30-85fc-fa1cc04038d4
-
 .LINK
 https://boxstarter.org
-
+Get-BoxstarterConsentPromptBehaviorAdmin
 #>
+function Set-BoxstarterConsentPromptBehaviorAdmin {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True)]
-        [Validateset('NeverNotify', 'NotifyOnAppInstallWithoutDimming', 'NotifyOnAppInstall', 'PromptForConsent', 'PromptForCredentials', 'AlwaysNotify')]
+        [Validateset(
+            'NeverNotify', 
+            'NotifyOnAppInstallWithoutDimming', 
+            'NotifyOnAppInstall', 
+            'PromptForConsent', 
+            'PromptForCredentials', 
+            'AlwaysNotify')]
         [string]
         $ConsentPromptBehavior
     )
-    $value = switch ($ConsentPromptBehavior) {
-        'NeverNotify' { 0 }
-        # 'NotifyOnAppInstallWithoutDimming' { 5 }
-        'NotifyOnAppInstall' { 5 }
-        'AlwaysNotify' { 2 }
+
+    $hklmuac = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+
+    $uacState = Get-ItemProperty -Path $hklmuac -Name EnableLUA -ErrorAction SilentlyContinue
+    if ($null -eq $uacState -or $uacState.EnableLUA -eq 0) {
+        Enable-UAC
     }
-    Write-BoxstarterMessage "Setting ConsentPromptBehaviorAdmin to $ConsentPromptBehavior"
-    Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
-        -Name ConsentPromptBehaviorAdmin `
-        -Value $value `
-        -Type DWord `
-        -Force
+
+    $valAdmin, $valSecDesktop = switch ($ConsentPromptBehavior) {
+        'NeverNotify' { 0, 0 }
+        'NotifyOnAppInstallWithoutDimming' { 5, 0 }
+        'NotifyOnAppInstall' { 5, 1 }
+        'AlwaysNotify' { 2, 1 }
+    }
+    Write-BoxstarterMessage "Setting ConsentPromptBehavior to $ConsentPromptBehavior"
+    Set-ItemProperty -Path $hklmuac -Name ConsentPromptBehaviorAdmin -Value $valAdmin -Type DWord -Force
+    Set-ItemProperty -Path $hklmuac -Name PromptOnSecureDesktop -Value $valSecDesktop -Type DWord -Force
 }

--- a/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterConsentPromptBehaviorAdmin.ps1
@@ -11,11 +11,11 @@ function Set-BoxstarterConsentPromptBehaviorAdmin {
     param (
         [Parameter(Mandatory = $True)]
         [Validateset(
-            'NeverNotify', 
-            'NotifyOnAppInstallWithoutDimming', 
-            'NotifyOnAppInstall', 
-            'PromptForConsent', 
-            'PromptForCredentials', 
+            'NeverNotify',
+            'NotifyOnAppInstallWithoutDimming',
+            'NotifyOnAppInstall',
+            'PromptForConsent',
+            'PromptForCredentials',
             'AlwaysNotify')]
         [string]
         $ConsentPromptBehavior


### PR DESCRIPTION
## Description Of Changes

With this change, two new functions `Get-BoxstarterConsentPromptBehaviorAdmin* and `Set-BoxstarterConsentPromptBehaviorAdmin` are added to `BoxStarter.WinConfig`.
These functions are used in `Cleanup-Boxstarter` to modify the UAC level instead of disabling it for the duration of the Boxstarter procedure. (only applies for Windows versions newer than Server 2016 - those that do support UAC levels)

## Motivation and Context
This implements #581

Whenever Boxstarter re-enables UAC after it triggered a reboot the UAC is in a 'foggy state' - ignoring ConsentPromptBehavior etc.
In order to bring the host to a clean state again the host needs to be rebooted again.
This 'final reboot' cannot be done from Boxstarter since the reboot would not be a fenced login/suspended bitlocker etc.

## Testing

![Uploading Peek 2025-06-23 21-40.gif…]()

1. manually `Get/Set-BoxstarterConsentPromptBehaviorAdmin`
1. manually Boxstarter package install with enabled uac

### Operating Systems Testing
- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #581
