### PR TITLE
Invoke-BoxstarterBuild without package name builds all packages

### DIFF
--- a/Boxstarter.Chocolatey/Invoke-BoxstarterBuild.ps1
+++ b/Boxstarter.Chocolatey/Invoke-BoxstarterBuild.ps1
@@ -23,10 +23,9 @@ New-BoxstarterPackage
 #>
     [CmdletBinding()]
     param(
-        [Parameter(Position=0,ParameterSetName='name')]
+        [Parameter(Position=0)]
         [string]$name,
-        [Parameter(Position=0,ParameterSetName='all')]
-        [switch]$all,
+        [switch]$all, # keep for backwards compatibility (not used, but required for compatibility, equivalent to !name)
         [switch]$quiet
     )
     if(!$boxstarter -or !$boxstarter.LocalRepo){
@@ -45,22 +44,20 @@ New-BoxstarterPackage
                 Write-BoxstarterMessage "Your package has been built. Using Boxstarter.bat $name or Install-BoxstarterPackage $name will run this package." -nologo
             }
         } else {
-             if($all){
-                Write-BoxstarterMessage "Scanning $($Boxstarter.LocalRepo) for package folders"
-                Get-ChildItem . | Where-Object { $_.PSIsContainer } | ForEach-Object {
-                    $directoriesExist = $true
-                    Write-BoxstarterMessage "Found directory $($_.name). Looking for $($_.name).nuspec"
-                    $nuspecCandidate = Join-Path -Path $_.Name -ChildPath "$($_.Name).nuspec"
-                    if(Test-Path $nuspecCandidate){
-                        Call-Chocolatey -Command Pack -PackageNames (Join-Path -Path . -ChildPath $nuspecCandidate) | Out-Null
-                        if(!$quiet){
-                            Write-BoxstarterMessage "Your package has been built. Using Boxstarter.bat $($_.Name) or Install-BoxstarterPackage $($_.Name) will run this package." -nologo
-                        }
+            Write-BoxstarterMessage "Scanning $($Boxstarter.LocalRepo) for package folders"
+            Get-ChildItem . | Where-Object { $_.PSIsContainer } | ForEach-Object {
+                $directoriesExist = $true
+                Write-BoxstarterMessage "Found directory $($_.name). Looking for $($_.name).nuspec"
+                $nuspecCandidate = Join-Path -Path $_.Name -ChildPath "$($_.Name).nuspec"
+                if(Test-Path $nuspecCandidate){
+                    Call-Chocolatey -Command Pack -PackageNames (Join-Path -Path . -ChildPath $nuspecCandidate) | Out-Null
+                    if(!$quiet){
+                        Write-BoxstarterMessage "Your package has been built. Using Boxstarter.bat $($_.Name) or Install-BoxstarterPackage $($_.Name) will run this package." -nologo
                     }
                 }
-                if($directoriesExist -eq $null){
-                    Write-BoxstarterMessage "No Directories exist under $($boxstarter.LocalRepo)"
-                }
+            }
+            if($directoriesExist -eq $null){
+                Write-BoxstarterMessage "No Directories exist under $($boxstarter.LocalRepo)"
             }
         }
     }


### PR DESCRIPTION
## Description Of Changes

`Invoke-BoxstarterBuild` now behaves identically to `Invoke-BoxstarterBuild -all` 
=> `-all` should be equivalent to `-name:$null`

## Motivation and Context

fix bug in parameter set name

## Testing

tested manually

### Operating Systems Testing

- Windows Server 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #50

