### PR TITLE
Boxstarter Reboot Logic broken if started from BoxstarterShell - Fixes for GH-590

### DIFF
--- a/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
+++ b/Boxstarter.Bootstrapper/Cleanup-Boxstarter.ps1
@@ -18,7 +18,7 @@ function Cleanup-Boxstarter {
         Remove-Item "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC"
         Enable-UAC
         if ($uacLevel) {
-            Set-BoxstarterConsentPromptBehaviorAdmin -ConsentPromptBehaviorAdmin $uacLevel
+            Set-BoxstarterConsentPromptBehaviorAdmin -ConsentPromptBehavior $uacLevel
             Write-BoxstarterMessage "Re-enabled UAC with ConsentPromptBehaviorAdmin set to $uacLevel"
         }
     }
@@ -70,7 +70,7 @@ function Cleanup-Boxstarter {
             if (-Not (Test-Path "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC")) {
                 Set-Content "$(Get-BoxstarterTempDir)\BoxstarterReEnableUAC" $uacLevel
             }
-            Set-BoxstarterConsentPromptBehaviorAdmin -ConsentPromptBehaviorAdmin 'NeverNotify'
+            Set-BoxstarterConsentPromptBehaviorAdmin -ConsentPromptBehavior 'NeverNotify'
         }
     }
 

--- a/Boxstarter.Bootstrapper/Invoke-Boxstarter.ps1
+++ b/Boxstarter.Bootstrapper/Invoke-Boxstarter.ps1
@@ -91,7 +91,7 @@ Invoke-Reboot
             $encryptedPass = convertfrom-securestring -securestring $password
             $passwordArg = "-encryptedPassword $encryptedPass"
         }
-        $command = "-ExecutionPolicy bypass -noexit -command Import-Module `"$($unNormalized.FullName)`";Invoke-Boxstarter $(if($RebootOk){'-RebootOk'}) $passwordArg"
+        $command = "-ExecutionPolicy bypass -noexit -command Import-Module `"$($unNormalized.FullName)`" -DisableNameChecking; Invoke-Boxstarter $(if($RebootOk){'-RebootOk'}) $passwordArg"
         Start-Process powershell -verb runas -argumentlist $command
         return
     }

--- a/Boxstarter.Bootstrapper/Invoke-Reboot.ps1
+++ b/Boxstarter.Bootstrapper/Invoke-Reboot.ps1
@@ -41,8 +41,9 @@ about_boxstarter_variable_in_bootstrapper
         $startup = "$env:appdata\Microsoft\Windows\Start Menu\Programs\Startup"
 
         # create the restart script
-        # no need to elevate here, Invoke-Boxstarter will Test-Admin and elevate if necessary
-        $restartScript = "Call PowerShell -NoProfile -ExecutionPolicy bypass -command `"Import-Module '$($Boxstarter.BaseDir)\Boxstarter.Bootstrapper\boxstarter.bootstrapper.psd1';Invoke-Boxstarter -RebootOk -NoPassword:`$$($Boxstarter.NoPassword.ToString())`""
+        $restartScript = "@echo off
+powershell -NoProfile -ExecutionPolicy Bypass -Command Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -Command `"Import-Module ''$($Boxstarter.BaseDir)\Boxstarter.Bootstrapper\boxstarter.bootstrapper.psd1'' -DisableNameChecking; Invoke-Boxstarter -RebootOk -NoPassword:`$$($Boxstarter.NoPassword.ToString())`"' -Verb RunAs
+"
         New-Item "$startup\boxstarter-post-restart.bat" -type file -Force -Value $restartScript | Out-Null
     }
     try {

--- a/BuildScripts/chocolateyinstall.ps1
+++ b/BuildScripts/chocolateyinstall.ps1
@@ -1,11 +1,24 @@
-$tools = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$tools = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 . (Join-Path $tools Setup.ps1)
 try {
-    $ModuleName = (Get-ChildItem $tools | ?{ $_.PSIsContainer }).BaseName
+    $ModuleName = (Get-ChildItem $tools | Where-Object { $_.PSIsContainer }).BaseName
+    if (-not $ModuleName) {
+        throw "No module found in $tools"
+    }
+    Write-Verbose "Installing Boxstarter module $ModuleName"
     $preInstall = Join-Path $tools "$modulename.preinstall.ps1"
-    if(Test-Path $preInstall) { .$preInstall }
+    if (Test-Path $preInstall) { 
+        Write-Verbose "Running pre-install script: $preInstall"
+        . $preInstall 
+    }
+    Write-Verbose 'Install-Boxstarter ...'
     Install-Boxstarter $tools $ModuleName $env:chocolateyPackageParameters
-} catch {
-    Write-Output $_ | fl * -force
+}
+catch {
+    Write-Output "An error occurred during installation of Boxstarter module $ModuleName"
+    Write-Output 'Error details:'
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    Write-Verbose 'Full error details:'
+    $_.Exception | Format-List * -Force | Write-Verbose
     throw $_.Exception
 }

--- a/BuildScripts/setup.ps1
+++ b/BuildScripts/setup.ps1
@@ -128,11 +128,18 @@ function Install-Boxstarter($here, $ModuleName, $installArgs = "") {
     $boxModule=Get-Module Boxstarter.Chocolatey
     if($boxModule) {
         if($boxModule.Path -like "$env:LOCALAPPDATA\Apps\*") {
+            Write-Verbose "Boxstarter.Chocolatey Module is installed in a ClickOnce location."
             $clickonce=$true
         }
     }
-    if(!$clickonce){
-        Import-Module "$boxstarterPath\$ModuleName" -DisableNameChecking -Force -ErrorAction SilentlyContinue
+    if(-Not $clickonce){
+        Write-Verbose "Importing  $boxstarterPath\$ModuleName Module"
+        try {
+            Import-Module "$boxstarterPath\$ModuleName" -DisableNameChecking -Force -ErrorAction SilentlyContinue
+        } catch {
+            # TODO: I _think_ it is safe to ignore module import failure at this point - need to check!
+            Write-Verbose "An error occurred while importing the $ModuleName module from $boxstarterPath"
+        }
     }
     $successMsg = @"
 The $ModuleName Module has been copied to $boxstarterPath and added to your Module path.


### PR DESCRIPTION

## Description Of Changes

I've done some more testing using prerelease-build packages with the current state of 'develop'
- these fixes are neccessary, - were missing in GH-590

## Motivation and Context

make it work

## Testing

yes, that's the point

### Operating Systems Testing

- Windows Server 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

