### PR TITLE
(maint) Update github url

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-boxstarter-release.md
+++ b/.github/ISSUE_TEMPLATE/new-boxstarter-release.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 
 > [!NOTE]
-> This release process documents the process of deploying a new version of [Boxstarter](https://github.com/chocolatey/boxstarter).
+> This release process documents the process of deploying a new version of [Boxstarter](https://github.com/chocolatey-community/boxstarter).
 
 
 - [ ] GitHub Milestone: <insert link here, once milestone has been created>
@@ -26,7 +26,7 @@ assignees: ''
   - [ ] A support/* branch if doing a backport/bugfix release for an earlier supported version, or
   - [ ] The hotfix/* or release/* branch, if a beta package is being released, or
   - [ ] The develop branch, if an alpha package is being released.
-- [ ] Make sure that all issues in the upcoming milestone have exactly one of the [GitReleaseManager category labels](https://github.com/chocolatey/boxstarter/blob/develop/GitReleaseManager.yaml#L1-L9) associated with them or [one of the ignored labels](https://github.com/chocolatey/boxstarter/blob/develop/GitReleaseManager.yaml#L11-L13).
+- [ ] Make sure that all issues in the upcoming milestone have exactly one of the [GitReleaseManager category labels](https://github.com/chocolatey-community/boxstarter/blob/develop/GitReleaseManager.yaml#L1-L9) associated with them or [one of the ignored labels](https://github.com/chocolatey-community/boxstarter/blob/develop/GitReleaseManager.yaml#L11-L13).
 - [ ] If the GitHub milestone issues are still open, confirm that that are done before moving on. If they are in fact done, apply the `4 - Done` label and close the issue.
 - [ ] Run the following command to generate release notes `.\GitReleaseManager.exe create -c <target-branch> -m <milestone> -n <milestone> --token <token> -o chocolatey -r boxstarter`
   - [ ] NOTE: Boxstarter build process does not include the installation of GitReleaseManager, so you will need to have it installed, either through Chocolatey or .NET Global Tools.
@@ -38,7 +38,7 @@ assignees: ''
 - [ ] This step should only be done if this is NOT a beta release. Merge the hotfix or release branch into the target branch. This could be either master or support branch
   - [ ] `git checkout <target branch name>`
   - [ ] `git merge --no-ff <branch name>` i.e. hotfix/4.1.1 or release/4.2.0 whatever branch you are working on just now
-- [ ] Push the changes to [upstream repository](https://github.com/chocolatey/boxstarter)
+- [ ] Push the changes to [upstream repository](https://github.com/chocolatey-community/boxstarter)
   - [ ] `git push upstream` - here upstream is assumed to be the above repository
   - [ ] `git push origin` - here origin is assumed to be your fork on the above repository
 - [ ] Assuming everyone is happy, Publish the GitHub release
@@ -51,7 +51,7 @@ assignees: ''
     $assets = (ls "*") -join ','
     .\GitReleaseManager addasset -t 3.0.3 -o chocolatey -r boxstarter --token "<token_here>" -a "$assets"
     ```
-- [ ] Move closed issues to  `5 - Released` at [https://github.com/chocolatey/boxstarter/issues?q=is%3Aissue+is%3Aclosed+label%3A%224+-+Done%22](https://github.com/chocolatey/boxstarter/issues?q=is%3Aissue+is%3Aclosed+label%3A%224+-+Done%22)
+- [ ] Move closed issues to  `5 - Released` at [https://github.com/chocolatey-community/boxstarter/issues?q=is%3Aissue+is%3Aclosed+label%3A%224+-+Done%22](https://github.com/chocolatey-community/boxstarter/issues?q=is%3Aissue+is%3Aclosed+label%3A%224+-+Done%22)
   - [ ] NOTE: This step should only be performed if this is a stable release. If an alpha/beta release, these issues won't be moved to released until the stable release is completed
 - [ ] Use GitReleaseManager to close the milestone to that all associated issues are updated with a message saying that this has been released
   - [ ] NOTE: This step should only be performed if this is a stable release. While on an alpha/beta release we don't want to update the issues, since this will happen on the final stable release.
@@ -75,7 +75,7 @@ assignees: ''
   - [ ] NOTE: These steps should only be completed if there are no plans to do subsequent alpha/beta releases for this package version.
   - [ ] `git branch -d <hotfix or release branch name>`
   - [ ] If the hotfix or release branch was pushed to the upstream repository, delete it from there as well
-- [ ] Push the changes to [upstream repository](https://github.com/chocolatey/boxstarter)
+- [ ] Push the changes to [upstream repository](https://github.com/chocolatey-community/boxstarter)
   - [ ] `git push upstream` - here upstream is assumed to be the above repository
   - [ ] `git push origin` - here origin is assumed to be your fork on the above repository
 - [ ] Next we need to update the boxstarter.org website with the new version of Boxstarter

--- a/BuildScripts/VERIFICATION.txt
+++ b/BuildScripts/VERIFICATION.txt
@@ -3,6 +3,6 @@ Verification is intended to assist the Chocolatey moderators and community in ve
 
 To verify the files using the project source:
 
-1. Please go to the project source location (https://github.com/chocolatey/boxstarter);
+1. Please go to the project source location (https://github.com/chocolatey-community/boxstarter);
 2. Download the source files for the module you want to verify. Make sure the version of the file you download is the same version as the files from the package you want to verify;
 3. For each source file use Get-FileHash -Path <FILE TO VERIFY> to get the file hash value from both the downloaded file (from step 1 above) and the file from the package and compare them;

--- a/BuildScripts/nuget/Boxstarter.Azure.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Azure.nuspec
@@ -11,9 +11,9 @@
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Azure support for Boxstarter</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's Azure module includes functionality for targeting Azure VMs with the ability to save and restore checkpoints leveraging blob snapshots.
 
 ## Package parameters
@@ -26,7 +26,7 @@
       <dependency id="WindowsAzurePowershell" version="1.6.0.20180408" />
     </dependencies>
     <releaseNotes>
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/BuildScripts/nuget/Boxstarter.Bootstrapper.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Bootstrapper.nuspec
@@ -11,9 +11,9 @@
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Bootstrapper module for Boxstarter</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's Bootstrapper module provides a PowerShell wrapper that supports reboots and automatic logons and exposes commands that can detect pending reboots, perform logging and messaging, and several commands that can configure various windows settings.
 
 ## Package parameters
@@ -26,7 +26,7 @@
       <dependency id="Boxstarter.WinConfig" version="[$version$]" />
     </dependencies>
     <releaseNotes>
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
@@ -11,9 +11,9 @@
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Chocolatey module for Boxstarter</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <description>Creates a fresh developer (or non developer) environment from a bare OS utilizing PowerShell and Chocolatey. Installs Chocolatey, cutomizes windows settings, installs windows updates, handles reboots, installs windows features and your favorite applications.
 
 ## Package parameters
@@ -27,7 +27,7 @@
       <dependency id="Boxstarter.Bootstrapper" version="[$version$]" />
     </dependencies>
     <releaseNotes>
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/BuildScripts/nuget/Boxstarter.Common.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Common.nuspec
@@ -12,9 +12,9 @@
     <title>Boxstarter Common Module</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Common module for Boxstarter</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <description>Provides common functions used by multiple Boxstarter Modules.
 
 ## Package parameters
@@ -23,7 +23,7 @@
     </description>
     <tags>boxstarter</tags>
     <releaseNotes xmlns="">
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/BuildScripts/nuget/Boxstarter.HyperV.nuspec
+++ b/BuildScripts/nuget/Boxstarter.HyperV.nuspec
@@ -11,9 +11,9 @@
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Hyper-V support for Boxstarter</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's HyperV module includes functionality for targeting Hyper-V guest VMs with the ability to automatically configure them for remote installation and to create or restore snapshots at installation time.
 
 ## Package parameters
@@ -26,7 +26,7 @@
       <dependency id="Boxstarter.Chocolatey" version="[$version$]" />
     </dependencies>
     <releaseNotes>
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/BuildScripts/nuget/Boxstarter.TestRunner.nuspec
+++ b/BuildScripts/nuget/Boxstarter.TestRunner.nuspec
@@ -11,9 +11,9 @@
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Test runner module for Boxstarter</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's Test Runner module makes it easy to automate the testing and publishing of Chocolatey packages.
 ## Package parameters
 
@@ -25,7 +25,7 @@
       <dependency id="Boxstarter.Azure" version="[$version$]" />
     </dependencies>
     <releaseNotes>
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/BuildScripts/nuget/Boxstarter.WinConfig.nuspec
+++ b/BuildScripts/nuget/Boxstarter.WinConfig.nuspec
@@ -12,9 +12,9 @@
     <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Windows environment module for Boxstarter</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <description>Functions that Boxstarter uses to customize the windows environment.
 
 ## Package parameters
@@ -26,7 +26,7 @@
       <dependency id="Boxstarter.Common" version="[$version$]" />
     </dependencies>
     <releaseNotes xmlns="">
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/BuildScripts/nuget/Boxstarter.nuspec
+++ b/BuildScripts/nuget/Boxstarter.nuspec
@@ -12,9 +12,9 @@
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <description>Repeatable, reboot resilient windows environment installations made easy using Chocolatey packages. When its time to repave either bare metal or virtualized instances, locally or on a remote machine, Boxstarter can automate both trivial and highly complex installations. Compatible with all Windows versions from Windows 7/2008 R2 forward.</description>
     <summary>Boxstarter provides repeatable, reboot resilient installs</summary>
-    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
-    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey-community/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey-community/boxstarter/issues</bugTrackerUrl>
     <tags>Boxstarter environment setup</tags>
     <dependencies>
       <dependency id="Boxstarter.Common" version="[$version$]" />
@@ -24,7 +24,7 @@
       <dependency id="Boxstarter.HyperV" version="[$version$]" />
     </dependencies>
     <releaseNotes>
-See information here: https://github.com/chocolatey/boxstarter/releases
+See information here: https://github.com/chocolatey-community/boxstarter/releases
 </releaseNotes>
   </metadata>
   <files>

--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -24,7 +24,7 @@ We like to see folks contributing to Boxstarter. If you are a committer, we'd li
 
 In all cases politeness goes a long way. Please thank folks for contributions - they are going out of their way to help make the code base better, or adding something they may personally feel is necessary for the code base.
 
-Please be VERY familiar with [CONTRIBUTING](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) and follow the process as well.
+Please be VERY familiar with [CONTRIBUTING](https://github.com/chocolatey-community/boxstarter/blob/master/CONTRIBUTING.md) and follow the process as well.
 
 ## Terminology
 **Contributor** - A person who makes a change to the code base and submits a change set in the form of a pull request.
@@ -39,11 +39,11 @@ Please be VERY familiar with [CONTRIBUTING](https://github.com/chocolatey/boxsta
  * A committer typically reviews it within a week or less to determine the feasibility of the changes.
 
 ### Initial PR Review
- * Did the user create a branch with these changes? If it is on their master, please ask them to review [CONTRIBUTING](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md).
+ * Did the user create a branch with these changes? If it is on their master, please ask them to review [CONTRIBUTING](https://github.com/chocolatey-community/boxstarter/blob/master/CONTRIBUTING.md).
  * Did the user reformat files and they should not have? Was is just white-space? You can try adding [?w=1](https://github.com/blog/967-github-secrets) to the URL on GitHub.
- * Are there tests? We really want any new contributions to contain tests so unless the committer believes this code really needs to be in the code base and is willing to write the tests, then we need to ask the contributor to make a good faith effort in adding test cases. Ask them to review the [contributing document](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) and provide tests. **Note:** Some commits may be refactoring which wouldn't necessarily add additional test sets.
+ * Are there tests? We really want any new contributions to contain tests so unless the committer believes this code really needs to be in the code base and is willing to write the tests, then we need to ask the contributor to make a good faith effort in adding test cases. Ask them to review the [contributing document](https://github.com/chocolatey-community/boxstarter/blob/master/CONTRIBUTING.md) and provide tests. **Note:** Some commits may be refactoring which wouldn't necessarily add additional test sets.
  * Is the code documented properly? Does this additional set of changes require changes to the [docs](https://boxstarter.org/WhyBoxstarter)?
- * Was this code warranted? Did the contributor follow the process of gaining approval for big change sets? If not please have them review the [contributing document](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) and ask that they follow up with a case for putting the code into the code base on the mailing list.
+ * Was this code warranted? Did the contributor follow the process of gaining approval for big change sets? If not please have them review the [contributing document](https://github.com/chocolatey-community/boxstarter/blob/master/CONTRIBUTING.md) and ask that they follow up with a case for putting the code into the code base on the mailing list.
 
 ### Review the Code
   * Does the code meet the naming conventions and formatting?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,14 +23,14 @@ The Chocolatey team has very explicit information here regarding the process for
 
 ## Reporting an Issue/Bug?
 
-Submitting an Issue (or a Bug)? See the [Submitting Issues](https://github.com/chocolatey/boxstarter#submitting-issues) section in the [README](https://github.com/chocolatey/boxstarter/blob/master/README.md#submitting-issues).
+Submitting an Issue (or a Bug)? See the [Submitting Issues](https://github.com/chocolatey-community/boxstarter#submitting-issues) section in the [README](https://github.com/chocolatey-community/boxstarter/blob/master/README.md#submitting-issues).
 
 ## Submitting an Enhancement / Feature Request
 
 Log a GitHub issue. There are less constraints on this versus reporting issues. The process for contributions is roughly as follows:
 
 * Submit the Enhancement ticket. You will need the issue id for your commits.
-* You agree to follow the [etiquette regarding communication](https://github.com/chocolatey/boxstarter#etiquette-regarding-communication).
+* You agree to follow the [etiquette regarding communication](https://github.com/chocolatey-community/boxstarter#etiquette-regarding-communication).
 
 ## Definition of Trivial Contributions
 
@@ -53,7 +53,7 @@ What is generally not considered trivial:
 * Through a GitHub issue (preferred), through the [mailing list](https://groups.google.com/forum/#!forum/boxstarter), or through [Community Chat](https://ch0.co/community), talk about a feature you would like to see (or a bug fix), and why it should be in Boxstarter.
     * If approved through the mailing list or in [Community Chat](https://ch0.co/community), ensure the accompanying GitHub issue is created with information and a link back to the mailing list discussion (or the Community Chat conversation).
 * Once you get a nod from one of the [Chocolatey Team](https://github.com/chocolatey?tab=members), you can start on the feature.
-* Alternatively, if a feature is on the issues list with the [Up For Grabs](https://github.com/chocolatey/boxstarter/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+For+Grabs%22) label, it is open for a community member (contributor) to patch. You should comment that you are signing up for it on the issue so someone else doesn't also sign up for the work.
+* Alternatively, if a feature is on the issues list with the [Up For Grabs](https://github.com/chocolatey-community/boxstarter/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+For+Grabs%22) label, it is open for a community member (contributor) to patch. You should comment that you are signing up for it on the issue so someone else doesn't also sign up for the work.
 
 ### Set Up Your Environment
 
@@ -64,7 +64,7 @@ What is generally not considered trivial:
     1. Open a command line and navigate to that directory.
     1. Add the upstream fork
         - If [**Using SSH agent forwarding**](https://docs.github.com/en/free-pro-team@latest/developers/overview/using-ssh-agent-forwarding) - `git remote add upstream git@github.com:chocolatey/boxstarter.git`
-        - If using **HTTPS cloning** (if you are unsure, use this one) - `git remote add upstream https://github.com/chocolatey/boxstarter.git`
+        - If using **HTTPS cloning** (if you are unsure, use this one) - `git remote add upstream https://github.com/chocolatey-community/boxstarter.git`
     1. Run `git fetch upstream`
     1. Ensure you have user name and email set appropriately to attribute your contributions - see [Name](https://help.github.com/articles/setting-your-username-in-git/) / [Email](https://help.github.com/articles/setting-your-commit-email-address-in-git/).
     1. Ensure that the local repository has the following settings (without `--global`, these only apply to the *current* repository):

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repeatable, reboot resilient windows environment installations made easy using C
 
 For more information and How Tos, visit [the official Boxstarter website](https://boxstarter.org).
 
-The source of the Boxstarter website can be found in the [boxstarter.org repository](https://github.com/chocolatey/boxstarter.org).
+The source of the Boxstarter website can be found in the [boxstarter.org repository](https://github.com/chocolatey-community/boxstarter.org).
 
 ## Windows Environment Creation Made Easy
 
@@ -79,7 +79,7 @@ Boxstarter requires the following to work:
 
 ### License / Credits
 
-Apache 2.0 - see [LICENSE](https://github.com/chocolatey/boxstarter/blob/master/LICENSE.txt) and [NOTICE](https://github.com/chocolatey/boxstarter/blob/master/NOTICE.txt) files.
+Apache 2.0 - see [LICENSE](https://github.com/chocolatey-community/boxstarter/blob/master/LICENSE.txt) and [NOTICE](https://github.com/chocolatey-community/boxstarter/blob/master/NOTICE.txt) files.
 
 ## Etiquette Regarding Communication
 
@@ -95,9 +95,9 @@ Observe the following help for submitting an issue.
 ### Prerequisites
 
 * When creating an issue, please ensure you read the guidance at the top which includes links for Contributing and Submitting Issues documentation.
-* The issue has to do with Boxstarter itself and is not a [Boxstarter website issue](https://github.com/chocolatey/boxstarter.org), Chocolatey package issue, a Chocolatey product issue.
+* The issue has to do with Boxstarter itself and is not a [Boxstarter website issue](https://github.com/chocolatey-community/boxstarter.org), Chocolatey package issue, a Chocolatey product issue.
 * Please check to see if your issue already exists with a quick search of both open and closed issues. Start with one relevant term and then add if you get too many results.
-* You are not submitting an "Enhancement". Enhancements should observe [CONTRIBUTING](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) guidelines.
+* You are not submitting an "Enhancement". Enhancements should observe [CONTRIBUTING](https://github.com/chocolatey-community/boxstarter/blob/master/CONTRIBUTING.md) guidelines.
 * You are not submitting a question - questions are better served as [emails](https://groups.google.com/forum/#!forum/boxstarter) or [Community Chat](https://ch0.co/community).
 * Please make sure you've read over and agree with the [etiquette regarding communication](#etiquette-regarding-communication).
 
@@ -113,8 +113,8 @@ Observe the following help for submitting an issue.
 
 ## Contributing
 
-If you would like to contribute code or help squash a bug or two, that's awesome. Please familiarize yourself with [CONTRIBUTING](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md).
+If you would like to contribute code or help squash a bug or two, that's awesome. Please familiarize yourself with [CONTRIBUTING](https://github.com/chocolatey-community/boxstarter/blob/master/CONTRIBUTING.md).
 
 ## Committers
 
-Committers, you should be very familiar with [COMMITTERS](https://github.com/chocolatey/boxstarter/blob/master/COMMITTERS.md).
+Committers, you should be very familiar with [COMMITTERS](https://github.com/chocolatey-community/boxstarter/blob/master/COMMITTERS.md).


### PR DESCRIPTION
This updates the GitHub URLs used in the repository to point to the new repository in the chocolatey-community organization.