### PR TITLE
(maint) Add explicit permissions to label-sync workflow

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -14,6 +14,10 @@ on:
     # Uncomment the following line if using a repository specific label file, also remove this comment line
     #  - '.github/labels.yml'
 
+permissions:
+  content: read # Required to read the config file from the repository
+  issues: write # Required to create/update/delete labels
+
 jobs:
   labels:
     # We use ubuntu as the image, as it is typically faster and cheaper (on private repos).


### PR DESCRIPTION
## Description Of Changes

- Add `content: read` permission to allow reading the labels configuration file from the repository
- Add `issues: write` permission to enable creating, updating, and deleting labels

## Motivation and Context

Follows GitHub Actions security best practices by using least privilege principle with explicit permissions. Prevents potential permission-related failures when the workflow attempts to read config files or modify labels, and makes permission requirements transparent and maintainable.

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Build Related changes
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A