### PR TITLE
(maint) Fix label-sync workflow permissions key

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -15,7 +15,7 @@ on:
     #  - '.github/labels.yml'
 
 permissions:
-  content: read # Required to read the config file from the repository
+  contents: read # Required to read the config file from the repository
   issues: write # Required to create/update/delete labels
 
 jobs:


### PR DESCRIPTION
## Description Of Changes

- Change "content" to "contents" in the label-sync workflow permissions section to align with GitHub Actions API specification

## Motivation and Context

The workflow was using an incorrect permission key name. GitHub Actions requires "contents" (not "content") to properly grant repository access for reading files.

## Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Build Related changes
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A